### PR TITLE
More dedup and a more expressive ChangeObject

### DIFF
--- a/docs/advanced/Plugins.md
+++ b/docs/advanced/Plugins.md
@@ -126,16 +126,18 @@ following shape:
 
 ```javascript
 {
-  type: 'UPDATE' | 'REMOVE',
+  operation: 'CREATE' | 'READ' | 'UPDATE' | 'DELETE',
   entity: EntityName,
-  entities: EntityValue[]
+  apiFn: ApiFunctionName,
+  args: Any[]
+  values: EntityValue[],
 }
 ```
 
-At this point in time there is no difference made between adding new
-EntityValues and updating already present ones: Both events lead to a
-change of the type `UPDATE`.
-The `entities` field is guaranteed to be a list of EntityValues, even if
+It provides all information about which call triggered a change,
+including the arguments array.
+
+The `values` field is guaranteed to be a list of EntityValues, even if
 a change only affects a single entity.
 
 `addChangeListener` returns a deregistration function. Call it to stop

--- a/docs/advanced/Plugins.md
+++ b/docs/advanced/Plugins.md
@@ -126,10 +126,10 @@ following shape:
 
 ```javascript
 {
-  operation: 'CREATE' | 'READ' | 'UPDATE' | 'DELETE',
+  operation: 'CREATE' | 'READ' | 'UPDATE' | 'DELETE' | 'NO_OPERATION',
   entity: EntityName,
   apiFn: ApiFunctionName,
-  args: Any[]
+  args: Any[] | null
   values: EntityValue[],
 }
 ```
@@ -138,7 +138,8 @@ It provides all information about which call triggered a change,
 including the arguments array.
 
 The `values` field is guaranteed to be a list of EntityValues, even if
-a change only affects a single entity.
+a change only affects a single entity. The only expection are
+`NO_OPERATION` operations, which will always return `null` here.
 
 `addChangeListener` returns a deregistration function. Call it to stop
 listening for changes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ladda-cache",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "Data fetching layer with support for caching",
   "main": "dist/bundle.js",
   "dependencies": {

--- a/src/builder.js
+++ b/src/builder.js
@@ -127,6 +127,12 @@ const applyPlugin = curry((addChangeListener, config, entityConfigs, plugin) => 
   return mapApiFunctions(pluginDecorator, entityConfigs);
 });
 
+const createPluginList = (core, plugins) => {
+  return plugins.length ?
+    [core, dedupPlugin, ...plugins, dedupPlugin] :
+    [core, dedupPlugin];
+};
+
 // Config -> Api
 export const build = (c, ps = []) => {
   const config = getGlobalConfig(c);
@@ -136,5 +142,5 @@ export const build = (c, ps = []) => {
   const applyPlugin_ = applyPlugin(listenerStore.addChangeListener, config);
   const applyPlugins = reduce(applyPlugin_, entityConfigs);
   const createApi = compose(toApi, applyPlugins);
-  return createApi([cachePlugin(listenerStore.onChange), ...ps, dedupPlugin]);
+  return createApi(createPluginList(cachePlugin(listenerStore.onChange), ps));
 };

--- a/src/builder.spec.js
+++ b/src/builder.spec.js
@@ -195,7 +195,7 @@ describe('builder', () => {
           const changeObject = spy.args[0][0];
           expect(changeObject.entity).to.equal('user');
           expect(changeObject.apiFn).to.equal('getUsers');
-          expect(changeObject.type).to.equal('CREATE');
+          expect(changeObject.operation).to.equal('READ');
           expect(changeObject.values).to.deep.equal(users);
           expect(changeObject.args).to.deep.equal([]);
         });

--- a/src/builder.spec.js
+++ b/src/builder.spec.js
@@ -199,6 +199,24 @@ describe('builder', () => {
       });
     });
 
+    it('can call deregistration fn several times without harm', () => {
+      const spy = sinon.spy();
+
+      const plugin = ({ addChangeListener }) => {
+        const deregister = addChangeListener(spy);
+        deregister();
+        deregister();
+        deregister();
+        return ({ fn }) => fn;
+      };
+
+      const api = build(config(), [plugin]);
+
+      return api.user.getUsers().then(() => {
+        expect(spy).not.to.have.been.called;
+      });
+    });
+
     describe('allows plugins to add a listener, which gets notified on all cache changes', () => {
       it('on READ operations', () => {
         const spy = sinon.spy();

--- a/src/builder.spec.js
+++ b/src/builder.spec.js
@@ -152,6 +152,23 @@ describe('builder', () => {
       .then(() => done());
   });
 
+  it('applies dedup before and after the plugins, if there are any', () => {
+    const getAll = sinon.stub().returns(Promise.resolve([]));
+    getAll.operation = 'READ';
+    const conf = { test: { api: { getAll } } };
+    const plugin = () => ({ fn }) => () => {
+      fn();
+      fn();
+      return fn();
+    };
+    const api = build(conf, [plugin]);
+    api.test.getAll();
+    api.test.getAll();
+    return api.test.getAll().then(() => {
+      expect(getAll).to.have.been.calledOnce;
+    });
+  });
+
   describe('change listener', () => {
     it('exposes Ladda\'s listener/onChange interface to plugins', () => {
       const plugin = ({ addChangeListener }) => {

--- a/src/builder.spec.js
+++ b/src/builder.spec.js
@@ -179,24 +179,26 @@ describe('builder', () => {
       build(config(), [plugin]);
     });
 
-    it('allows plugins to add a listener, which gets notified on all cache changes', () => {
-      const spy = sinon.spy();
+    describe('allows plugins to add a listener, which gets notified on all cache changes', () => {
+      it('on READ operations', () => {
+        const spy = sinon.spy();
 
-      const plugin = ({ addChangeListener }) => {
-        addChangeListener(spy);
-        return ({ fn }) => fn;
-      };
+        const plugin = ({ addChangeListener }) => {
+          addChangeListener(spy);
+          return ({ fn }) => fn;
+        };
 
-      const api = build(config(), [plugin]);
+        const api = build(config(), [plugin]);
 
-      return api.user.getUsers().then(() => {
-        expect(spy).to.have.been.calledOnce;
-        const changeObject = spy.args[0][0];
-        expect(changeObject.entity).to.equal('user');
-        expect(changeObject.apiFn).to.equal('getUsers');
-        expect(changeObject.type).to.equal('CREATE');
-        expect(changeObject.values).to.deep.equal(users);
-        expect(changeObject.args).to.deep.equal([]);
+        return api.user.getUsers().then(() => {
+          expect(spy).to.have.been.calledOnce;
+          const changeObject = spy.args[0][0];
+          expect(changeObject.entity).to.equal('user');
+          expect(changeObject.apiFn).to.equal('getUsers');
+          expect(changeObject.type).to.equal('CREATE');
+          expect(changeObject.values).to.deep.equal(users);
+          expect(changeObject.args).to.deep.equal([]);
+        });
       });
     });
 

--- a/src/builder.spec.js
+++ b/src/builder.spec.js
@@ -193,8 +193,10 @@ describe('builder', () => {
         expect(spy).to.have.been.calledOnce;
         const changeObject = spy.args[0][0];
         expect(changeObject.entity).to.equal('user');
-        expect(changeObject.type).to.equal('UPDATE');
-        expect(changeObject.entities).to.deep.equal(users);
+        expect(changeObject.apiFn).to.equal('getUsers');
+        expect(changeObject.type).to.equal('CREATE');
+        expect(changeObject.values).to.deep.equal(users);
+        expect(changeObject.args).to.deep.equal([]);
       });
     });
 

--- a/src/plugins/cache/entity-store.js
+++ b/src/plugins/cache/entity-store.js
@@ -13,6 +13,7 @@
 
 import {curry, reduce, map_, clone} from 'ladda-fp';
 import {merge} from './merger';
+import {removeId} from './id-helper';
 
 // Value -> StoreValue
 const toStoreValue = v => ({value: v, timestamp: Date.now()});
@@ -122,7 +123,10 @@ export const remove = (es, e, id) => {
   const x = get(es, e, id);
   rm(es, createEntityKey(e, {__ladda__id: id}));
   rmViews(es, e);
-  return x;
+  if (x) {
+    return removeId(x.value);
+  }
+  return undefined;
 };
 
 // EntityStore -> Entity -> String -> Bool

--- a/src/plugins/cache/entity-store.spec.js
+++ b/src/plugins/cache/entity-store.spec.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-unused-expressions */
 
-import sinon from 'sinon';
 import {createEntityStore, put, mPut, get, contains, remove} from './entity-store';
 import {addId} from './id-helper';
 
@@ -230,61 +229,6 @@ describe('EntityStore', () => {
       const e = { name: 'user'};
       const fn = () => remove(s, e, v.id);
       expect(fn).to.not.throw();
-    });
-  });
-
-  describe('with a hook', () => {
-    describe('put', () => {
-      it('notifies with the put entity as singleton list', () => {
-        const hook = sinon.spy();
-        const s = createEntityStore(config, hook);
-        const v = {id: 'hello'};
-        const e = { name: 'user'};
-        put(s, e, addId({}, undefined, undefined, v));
-        expect(hook).to.have.been.called;
-
-        expect(hook).to.have.been.calledWith({
-          type: 'UPDATE',
-          entity: 'user',
-          entities: [v]
-        });
-      });
-    });
-
-    describe('mPut', () => {
-      it('notifies with the put entities', () => {
-        const hook = sinon.spy();
-        const s = createEntityStore(config, hook);
-        const v1 = {id: 'hello'};
-        const v2 = {id: 'there'};
-        const e = { name: 'user'};
-        const v1WithId = addId({}, undefined, undefined, v1);
-        const v2WithId = addId({}, undefined, undefined, v2);
-        mPut(s, e, [v1WithId, v2WithId]);
-
-        expect(hook).to.have.been.called;
-
-        const arg = hook.args[0][0];
-        expect(arg.type).to.equal('UPDATE');
-        expect(arg.entities).to.deep.equal([v1, v2]);
-      });
-    });
-
-    describe('rm', () => {
-      it('notifies with the removed entity as a singleton list', () => {
-        const hook = sinon.spy();
-        const s = createEntityStore(config, hook);
-        const v = {id: 'hello'};
-        const e = { name: 'user'};
-        put(s, e, addId({}, undefined, undefined, v));
-        remove(s, e, v.id);
-
-        expect(hook).to.have.been.calledTwice; // we also put!
-
-        const arg = hook.args[1][0];
-        expect(arg.type).to.equal('DELETE');
-        expect(arg.entities).to.deep.equal([v]);
-      });
     });
   });
 });

--- a/src/plugins/cache/index.js
+++ b/src/plugins/cache/index.js
@@ -15,13 +15,19 @@ const HANDLERS = {
 };
 
 const normalizeFnName = (fnName) => fnName.replace(/^bound /, '');
+const normalizePayload = payload => {
+  if (payload === null) {
+    return payload;
+  }
+  return Array.isArray(payload) ? payload : [payload];
+};
 
 const notify = curry((onChange, entity, fn, args, payload) => {
   onChange({
     operation: fn.operation,
     entity: entity.name,
     apiFn: normalizeFnName(fn.name),
-    values: Array.isArray(payload) ? payload : [payload],
+    values: normalizePayload(payload),
     args
   });
 });

--- a/src/plugins/cache/index.js
+++ b/src/plugins/cache/index.js
@@ -14,11 +14,13 @@ const HANDLERS = {
   NO_OPERATION: decorateNoOperation
 };
 
+const normalizeFnName = (fnName) => fnName.replace(/^bound /, '');
+
 const notify = curry((onChange, entity, fn, changeType, args, payload) => {
   onChange({
     type: changeType,
     entity: entity.name,
-    apiFn: fn.name,
+    apiFn: normalizeFnName(fn.name),
     values: Array.isArray(payload) ? payload : [payload],
     args
   });

--- a/src/plugins/cache/index.js
+++ b/src/plugins/cache/index.js
@@ -1,4 +1,4 @@
-import {values} from 'ladda-fp';
+import {curry, values} from 'ladda-fp';
 import {createCache} from './cache';
 import {decorateCreate} from './operations/create';
 import {decorateRead} from './operations/read';
@@ -14,10 +14,21 @@ const HANDLERS = {
   NO_OPERATION: decorateNoOperation
 };
 
+const notify = curry((onChange, entity, fn, changeType, args, payload) => {
+  onChange({
+    type: changeType,
+    entity: entity.name,
+    apiFn: fn.name,
+    values: Array.isArray(payload) ? payload : [payload],
+    args
+  });
+});
+
 export const cachePlugin = (onChange) => ({ config, entityConfigs }) => {
-  const cache = createCache(values(entityConfigs), onChange);
+  const cache = createCache(values(entityConfigs));
   return ({ entity, fn }) => {
     const handler = HANDLERS[fn.operation];
-    return handler(config, cache, entity, fn);
+    const notify_ = notify(onChange, entity, fn);
+    return handler(config, cache, notify_, entity, fn);
   };
 };

--- a/src/plugins/cache/index.js
+++ b/src/plugins/cache/index.js
@@ -16,9 +16,9 @@ const HANDLERS = {
 
 const normalizeFnName = (fnName) => fnName.replace(/^bound /, '');
 
-const notify = curry((onChange, entity, fn, changeType, args, payload) => {
+const notify = curry((onChange, entity, fn, args, payload) => {
   onChange({
-    type: changeType,
+    operation: fn.operation,
     entity: entity.name,
     apiFn: normalizeFnName(fn.name),
     values: Array.isArray(payload) ? payload : [payload],

--- a/src/plugins/cache/operations/create.js
+++ b/src/plugins/cache/operations/create.js
@@ -2,7 +2,7 @@ import {passThrough, compose} from 'ladda-fp';
 import {storeEntity, invalidateQuery} from '../cache';
 import {addId} from '../id-helper';
 
-export function decorateCreate(c, cache, e, aFn) {
+export function decorateCreate(c, cache, notify, e, aFn) {
   return (...args) => {
     return aFn(...args)
       .then(passThrough(() => invalidateQuery(cache, e, aFn)))

--- a/src/plugins/cache/operations/create.js
+++ b/src/plugins/cache/operations/create.js
@@ -7,6 +7,6 @@ export function decorateCreate(c, cache, notify, e, aFn) {
     return aFn(...args)
       .then(passThrough(() => invalidateQuery(cache, e, aFn)))
       .then(passThrough(compose(storeEntity(cache, e), addId(c, aFn, args))))
-      .then(passThrough(notify('CREATE', args)));
+      .then(passThrough(notify(args)));
   };
 }

--- a/src/plugins/cache/operations/create.js
+++ b/src/plugins/cache/operations/create.js
@@ -6,6 +6,7 @@ export function decorateCreate(c, cache, notify, e, aFn) {
   return (...args) => {
     return aFn(...args)
       .then(passThrough(() => invalidateQuery(cache, e, aFn)))
-      .then(passThrough(compose(storeEntity(cache, e), addId(c, aFn, args))));
+      .then(passThrough(compose(storeEntity(cache, e), addId(c, aFn, args))))
+      .then(passThrough(notify('CREATE', args)));
   };
 }

--- a/src/plugins/cache/operations/create.spec.js
+++ b/src/plugins/cache/operations/create.spec.js
@@ -41,7 +41,7 @@ const config = [
 
 describe('Create', () => {
   describe('decorateCreate', () => {
-    it('Adds value to entity store', (done) => {
+    it('Adds value to entity store', () => {
       const cache = createCache(config);
       const e = config[0];
       const xOrg = {name: 'Kalle'};
@@ -49,10 +49,9 @@ describe('Create', () => {
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(response));
       const aFn = sinon.spy(aFnWithoutSpy);
       const res = decorateCreate({}, cache, curryNoop, e, aFn);
-      res(xOrg).then((newX) => {
+      return res(xOrg).then((newX) => {
         expect(newX).to.equal(response);
         expect(getEntity(cache, e, 1).value).to.deep.equal({...response, __ladda__id: 1});
-        done();
       });
     });
   });

--- a/src/plugins/cache/operations/create.spec.js
+++ b/src/plugins/cache/operations/create.spec.js
@@ -60,7 +60,7 @@ describe('Create', () => {
 
     it('triggers a CREATE notification', () => {
       const spy = sinon.spy();
-      const n = curry((a, b, c) => spy(a, b, c));
+      const n = curry((a, b) => spy(a, b));
       const cache = createCache(config);
       const e = config[0];
       const xOrg = {name: 'Kalle'};
@@ -70,7 +70,7 @@ describe('Create', () => {
       const res = decorateCreate({}, cache, n, e, aFn);
       return res(xOrg).then((newX) => {
         expect(spy).to.have.been.calledOnce;
-        expect(spy).to.have.been.calledWith('CREATE', [xOrg], newX);
+        expect(spy).to.have.been.calledWith([xOrg], newX);
       });
     });
   });

--- a/src/plugins/cache/operations/create.spec.js
+++ b/src/plugins/cache/operations/create.spec.js
@@ -3,6 +3,8 @@ import {decorateCreate} from './create';
 import {createCache, getEntity} from '../cache';
 import {createApiFunction} from '../test-helper';
 
+const curryNoop = () => () => {};
+
 const config = [
   {
     name: 'user',
@@ -46,7 +48,7 @@ describe('Create', () => {
       const response = {...xOrg, id: 1};
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(response));
       const aFn = sinon.spy(aFnWithoutSpy);
-      const res = decorateCreate({}, cache, e, aFn);
+      const res = decorateCreate({}, cache, curryNoop, e, aFn);
       res(xOrg).then((newX) => {
         expect(newX).to.equal(response);
         expect(getEntity(cache, e, 1).value).to.deep.equal({...response, __ladda__id: 1});

--- a/src/plugins/cache/operations/create.spec.js
+++ b/src/plugins/cache/operations/create.spec.js
@@ -1,4 +1,7 @@
+/* eslint-disable no-unused-expressions */
+
 import sinon from 'sinon';
+import {curry} from 'ladda-fp';
 import {decorateCreate} from './create';
 import {createCache, getEntity} from '../cache';
 import {createApiFunction} from '../test-helper';
@@ -52,6 +55,22 @@ describe('Create', () => {
       return res(xOrg).then((newX) => {
         expect(newX).to.equal(response);
         expect(getEntity(cache, e, 1).value).to.deep.equal({...response, __ladda__id: 1});
+      });
+    });
+
+    it('triggers a CREATE notification', () => {
+      const spy = sinon.spy();
+      const n = curry((a, b, c) => spy(a, b, c));
+      const cache = createCache(config);
+      const e = config[0];
+      const xOrg = {name: 'Kalle'};
+      const response = {...xOrg, id: 1};
+      const aFnWithoutSpy = createApiFunction(() => Promise.resolve(response));
+      const aFn = sinon.spy(aFnWithoutSpy);
+      const res = decorateCreate({}, cache, n, e, aFn);
+      return res(xOrg).then((newX) => {
+        expect(spy).to.have.been.calledOnce;
+        expect(spy).to.have.been.calledWith('CREATE', [xOrg], newX);
       });
     });
   });

--- a/src/plugins/cache/operations/delete.js
+++ b/src/plugins/cache/operations/delete.js
@@ -9,7 +9,7 @@ export function decorateDelete(c, cache, notify, e, aFn) {
       .then(() => {
         const removed = Cache.removeEntity(cache, e, serialize(args));
         if (removed) {
-          notify('DELETE', args, removed);
+          notify(args, removed);
         }
       });
   };

--- a/src/plugins/cache/operations/delete.js
+++ b/src/plugins/cache/operations/delete.js
@@ -2,7 +2,7 @@ import {passThrough} from 'ladda-fp';
 import * as Cache from '../cache';
 import {serialize} from '../serializer';
 
-export function decorateDelete(c, cache, e, aFn) {
+export function decorateDelete(c, cache, notify, e, aFn) {
   return (...args) => {
     return aFn(...args)
       .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)))

--- a/src/plugins/cache/operations/delete.js
+++ b/src/plugins/cache/operations/delete.js
@@ -6,6 +6,11 @@ export function decorateDelete(c, cache, notify, e, aFn) {
   return (...args) => {
     return aFn(...args)
       .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)))
-      .then(() => Cache.removeEntity(cache, e, serialize(args)));
+      .then(() => {
+        const removed = Cache.removeEntity(cache, e, serialize(args));
+        if (removed) {
+          notify('DELETE', args, removed);
+        }
+      });
   };
 }

--- a/src/plugins/cache/operations/delete.spec.js
+++ b/src/plugins/cache/operations/delete.spec.js
@@ -4,6 +4,8 @@ import * as Cache from '../cache';
 import {addId} from '../id-helper';
 import {createApiFunction} from '../test-helper';
 
+const curryNoop = () => () => {};
+
 const config = [
   {
     name: 'user',
@@ -47,7 +49,7 @@ describe('Delete', () => {
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve({}));
       const aFn = sinon.spy(aFnWithoutSpy);
       Cache.storeEntity(cache, e, addId({}, undefined, undefined, xOrg));
-      const res = decorateDelete({}, cache, e, aFn);
+      const res = decorateDelete({}, cache, curryNoop, e, aFn);
       res(1).then(() => {
         expect(Cache.getEntity(cache, e, 1)).to.equal(undefined);
         done();

--- a/src/plugins/cache/operations/delete.spec.js
+++ b/src/plugins/cache/operations/delete.spec.js
@@ -42,7 +42,7 @@ const config = [
 
 describe('Delete', () => {
   describe('decorateDelete', () => {
-    it('Removes cache', (done) => {
+    it('Removes cache', () => {
       const cache = Cache.createCache(config);
       const e = config[0];
       const xOrg = {id: 1, name: 'Kalle'};
@@ -50,9 +50,8 @@ describe('Delete', () => {
       const aFn = sinon.spy(aFnWithoutSpy);
       Cache.storeEntity(cache, e, addId({}, undefined, undefined, xOrg));
       const res = decorateDelete({}, cache, curryNoop, e, aFn);
-      res(1).then(() => {
+      return res(1).then(() => {
         expect(Cache.getEntity(cache, e, 1)).to.equal(undefined);
-        done();
       });
     });
   });

--- a/src/plugins/cache/operations/delete.spec.js
+++ b/src/plugins/cache/operations/delete.spec.js
@@ -60,7 +60,7 @@ describe('Delete', () => {
 
     it('triggers DELETE notification', () => {
       const spy = sinon.spy();
-      const n = curry((a, b, c) => spy(a, b, c));
+      const n = curry((a, b) => spy(a, b));
       const cache = Cache.createCache(config);
       const e = config[0];
       const xOrg = {id: 1, name: 'Kalle'};
@@ -70,13 +70,13 @@ describe('Delete', () => {
       const res = decorateDelete({}, cache, n, e, aFn);
       return res(1).then(() => {
         expect(spy).to.have.been.calledOnce;
-        expect(spy).to.have.been.calledWith('DELETE', [1], xOrg);
+        expect(spy).to.have.been.calledWith([1], xOrg);
       });
     });
 
     it('does not trigger notification when item was not in cache', () => {
       const spy = sinon.spy();
-      const n = curry((a, b, c) => spy(a, b, c));
+      const n = curry((a, b) => spy(a, b));
       const cache = Cache.createCache(config);
       const e = config[0];
       const xOrg = {id: 1, name: 'Kalle'};

--- a/src/plugins/cache/operations/no-operation.js
+++ b/src/plugins/cache/operations/no-operation.js
@@ -4,6 +4,7 @@ import {invalidateQuery} from '../cache';
 export function decorateNoOperation(c, cache, notify, e, aFn) {
   return (...args) => {
     return aFn(...args)
-      .then(passThrough(() => invalidateQuery(cache, e, aFn)));
+      .then(passThrough(() => invalidateQuery(cache, e, aFn)))
+      .then(passThrough(() => notify(args, null)));
   };
 }

--- a/src/plugins/cache/operations/no-operation.js
+++ b/src/plugins/cache/operations/no-operation.js
@@ -1,7 +1,7 @@
 import {passThrough} from 'ladda-fp';
 import {invalidateQuery} from '../cache';
 
-export function decorateNoOperation(c, cache, e, aFn) {
+export function decorateNoOperation(c, cache, notify, e, aFn) {
   return (...args) => {
     return aFn(...args)
       .then(passThrough(() => invalidateQuery(cache, e, aFn)));

--- a/src/plugins/cache/operations/no-operation.spec.js
+++ b/src/plugins/cache/operations/no-operation.spec.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-expressions */
 
 import sinon from 'sinon';
+import {curry} from 'ladda-fp';
 import {decorateNoOperation} from './no-operation';
 import * as Cache from '../cache';
 import {createSampleConfig, createApiFunction} from '../test-helper';
@@ -51,8 +52,9 @@ describe('DecorateNoOperation', () => {
     });
   });
 
-  it('does not trigger notify', () => {
+  it('trigger notification', () => {
     const spy = sinon.spy();
+    const n = curry((a, b) => spy(a, b));
     const cache = Cache.createCache(config);
     const e = config[0];
     const xOrg = {__ladda__id: 1, name: 'Kalle'};
@@ -60,9 +62,10 @@ describe('DecorateNoOperation', () => {
     const getUsers = () => Promise.resolve(xOrg);
     aFn.invalidates = ['getUsers'];
     Cache.storeQueryResponse(cache, e, getUsers, ['args'], xOrg);
-    const res = decorateNoOperation({}, cache, spy, e, aFn);
+    const res = decorateNoOperation({}, cache, n, e, aFn);
     return res(xOrg).then(() => {
-      expect(spy).not.to.have.been.called;
+      expect(spy).to.have.been.calledOnce;
+      expect(spy).to.have.been.calledWith([xOrg], null);
     });
   });
 });

--- a/src/plugins/cache/operations/no-operation.spec.js
+++ b/src/plugins/cache/operations/no-operation.spec.js
@@ -10,7 +10,7 @@ const curryNoop = () => () => {};
 const config = createSampleConfig();
 
 describe('DecorateNoOperation', () => {
-  it('Invalidates based on what is specified in the original function', (done) => {
+  it('Invalidates based on what is specified in the original function', () => {
     const cache = Cache.createCache(config);
     const e = config[0];
     const xOrg = {__ladda__id: 1, name: 'Kalle'};
@@ -19,10 +19,9 @@ describe('DecorateNoOperation', () => {
     aFn.invalidates = ['getUsers'];
     Cache.storeQueryResponse(cache, e, getUsers, ['args'], xOrg);
     const res = decorateNoOperation({}, cache, curryNoop, e, aFn);
-    res(xOrg).then(() => {
+    return res(xOrg).then(() => {
       const killedCache = !Cache.containsQueryResponse(cache, e, getUsers, ['args']);
       expect(killedCache).to.be.true;
-      done();
     });
   });
   it('Does not change original function', () => {
@@ -34,7 +33,7 @@ describe('DecorateNoOperation', () => {
     decorateNoOperation({}, cache, curryNoop, e, aFn);
     expect(aFn.operation).to.be.undefined;
   });
-  it('Ignored inherited invalidation config', (done) => {
+  it('Ignored inherited invalidation config', () => {
     const cache = Cache.createCache(config);
     const e = config[0];
     const xOrg = {__ladda__id: 1, name: 'Kalle'};
@@ -44,10 +43,9 @@ describe('DecorateNoOperation', () => {
     aFn.hasOwnProperty = () => false;
     Cache.storeQueryResponse(cache, e, getUsers, ['args'], xOrg);
     const res = decorateNoOperation({}, cache, curryNoop, e, aFn);
-    res(xOrg).then(() => {
+    return res(xOrg).then(() => {
       const killedCache = !Cache.containsQueryResponse(cache, e, getUsers, ['args']);
       expect(killedCache).to.be.false;
-      done();
     });
   });
 });

--- a/src/plugins/cache/operations/no-operation.spec.js
+++ b/src/plugins/cache/operations/no-operation.spec.js
@@ -24,6 +24,7 @@ describe('DecorateNoOperation', () => {
       expect(killedCache).to.be.true;
     });
   });
+
   it('Does not change original function', () => {
     const cache = Cache.createCache(config);
     const e = config[0];
@@ -33,6 +34,7 @@ describe('DecorateNoOperation', () => {
     decorateNoOperation({}, cache, curryNoop, e, aFn);
     expect(aFn.operation).to.be.undefined;
   });
+
   it('Ignored inherited invalidation config', () => {
     const cache = Cache.createCache(config);
     const e = config[0];
@@ -46,6 +48,21 @@ describe('DecorateNoOperation', () => {
     return res(xOrg).then(() => {
       const killedCache = !Cache.containsQueryResponse(cache, e, getUsers, ['args']);
       expect(killedCache).to.be.false;
+    });
+  });
+
+  it('does not trigger notify', () => {
+    const spy = sinon.spy();
+    const cache = Cache.createCache(config);
+    const e = config[0];
+    const xOrg = {__ladda__id: 1, name: 'Kalle'};
+    const aFn = sinon.spy(() => Promise.resolve({}));
+    const getUsers = () => Promise.resolve(xOrg);
+    aFn.invalidates = ['getUsers'];
+    Cache.storeQueryResponse(cache, e, getUsers, ['args'], xOrg);
+    const res = decorateNoOperation({}, cache, spy, e, aFn);
+    return res(xOrg).then(() => {
+      expect(spy).not.to.have.been.called;
     });
   });
 });

--- a/src/plugins/cache/operations/no-operation.spec.js
+++ b/src/plugins/cache/operations/no-operation.spec.js
@@ -5,6 +5,8 @@ import {decorateNoOperation} from './no-operation';
 import * as Cache from '../cache';
 import {createSampleConfig, createApiFunction} from '../test-helper';
 
+const curryNoop = () => () => {};
+
 const config = createSampleConfig();
 
 describe('DecorateNoOperation', () => {
@@ -16,7 +18,7 @@ describe('DecorateNoOperation', () => {
     const getUsers = () => Promise.resolve(xOrg);
     aFn.invalidates = ['getUsers'];
     Cache.storeQueryResponse(cache, e, getUsers, ['args'], xOrg);
-    const res = decorateNoOperation({}, cache, e, aFn);
+    const res = decorateNoOperation({}, cache, curryNoop, e, aFn);
     res(xOrg).then(() => {
       const killedCache = !Cache.containsQueryResponse(cache, e, getUsers, ['args']);
       expect(killedCache).to.be.true;
@@ -29,7 +31,7 @@ describe('DecorateNoOperation', () => {
     const aFn = sinon.spy(() => {
       return Promise.resolve({});
     });
-    decorateNoOperation({}, cache, e, aFn);
+    decorateNoOperation({}, cache, curryNoop, e, aFn);
     expect(aFn.operation).to.be.undefined;
   });
   it('Ignored inherited invalidation config', (done) => {
@@ -41,7 +43,7 @@ describe('DecorateNoOperation', () => {
     const getUsers = createApiFunction(() => Promise.resolve(xOrg));
     aFn.hasOwnProperty = () => false;
     Cache.storeQueryResponse(cache, e, getUsers, ['args'], xOrg);
-    const res = decorateNoOperation({}, cache, e, aFn);
+    const res = decorateNoOperation({}, cache, curryNoop, e, aFn);
     res(xOrg).then(() => {
       const killedCache = !Cache.containsQueryResponse(cache, e, getUsers, ['args']);
       expect(killedCache).to.be.false;

--- a/src/plugins/cache/operations/read.js
+++ b/src/plugins/cache/operations/read.js
@@ -78,7 +78,7 @@ const decorateReadQuery = (c, cache, e, aFn) => {
   };
 };
 
-export function decorateRead(c, cache, e, aFn) {
+export function decorateRead(c, cache, notify, e, aFn) {
   if (aFn.byId) {
     return decorateReadSingle(c, cache, e, aFn);
   }

--- a/src/plugins/cache/operations/read.js
+++ b/src/plugins/cache/operations/read.js
@@ -19,7 +19,7 @@ const readFromCache = curry((cache, e, aFn, id) => {
   return undefined;
 });
 
-const decorateReadSingle = (c, cache, e, aFn) => {
+const decorateReadSingle = (c, cache, notify, e, aFn) => {
   return (id) => {
     const fromCache = readFromCache(cache, e, aFn, id);
     if (fromCache) {
@@ -28,11 +28,12 @@ const decorateReadSingle = (c, cache, e, aFn) => {
 
     return aFn(id)
       .then(passThrough(compose(Cache.storeEntity(cache, e), addId(c, aFn, id))))
-      .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)));
+      .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)))
+      .then(passThrough(notify('CREATE', [id])));
   };
 };
 
-const decorateReadSome = (c, cache, e, aFn) => {
+const decorateReadSome = (c, cache, notify, e, aFn) => {
   return (ids) => {
     const readFromCache_ = readFromCache(cache, e, aFn);
     const [cached, remaining] = reduce(([c_, r], id) => {
@@ -57,11 +58,12 @@ const decorateReadSome = (c, cache, e, aFn) => {
       .then((other) => {
         const asMap = compose(toIdMap, concat)(cached, other);
         return map((id) => asMap[id], ids);
-      });
+      })
+      .then(passThrough(notify('CREATE', [remaining])));
   };
 };
 
-const decorateReadQuery = (c, cache, e, aFn) => {
+const decorateReadQuery = (c, cache, notify, e, aFn) => {
   return (...args) => {
     if (Cache.containsQueryResponse(cache, e, aFn, args) && !aFn.alwaysGetFreshData) {
       const v = Cache.getQueryResponseWithMeta(cache, e, aFn, args);
@@ -74,16 +76,17 @@ const decorateReadQuery = (c, cache, e, aFn) => {
       .then(passThrough(
             compose(Cache.storeQueryResponse(cache, e, aFn, args),
                     addId(c, aFn, args))))
-      .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)));
+      .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)))
+      .then(passThrough(notify('CREATE', args)));
   };
 };
 
 export function decorateRead(c, cache, notify, e, aFn) {
   if (aFn.byId) {
-    return decorateReadSingle(c, cache, e, aFn);
+    return decorateReadSingle(c, cache, notify, e, aFn);
   }
   if (aFn.byIds) {
-    return decorateReadSome(c, cache, e, aFn);
+    return decorateReadSome(c, cache, notify, e, aFn);
   }
-  return decorateReadQuery(c, cache, e, aFn);
+  return decorateReadQuery(c, cache, notify, e, aFn);
 }

--- a/src/plugins/cache/operations/read.js
+++ b/src/plugins/cache/operations/read.js
@@ -29,7 +29,7 @@ const decorateReadSingle = (c, cache, notify, e, aFn) => {
     return aFn(id)
       .then(passThrough(compose(Cache.storeEntity(cache, e), addId(c, aFn, id))))
       .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)))
-      .then(passThrough(notify('CREATE', [id])));
+      .then(passThrough(notify([id])));
   };
 };
 
@@ -59,7 +59,7 @@ const decorateReadSome = (c, cache, notify, e, aFn) => {
         const asMap = compose(toIdMap, concat)(cached, other);
         return map((id) => asMap[id], ids);
       })
-      .then(passThrough(notify('CREATE', [remaining])));
+      .then(passThrough(notify([remaining])));
   };
 };
 
@@ -77,7 +77,7 @@ const decorateReadQuery = (c, cache, notify, e, aFn) => {
             compose(Cache.storeQueryResponse(cache, e, aFn, args),
                     addId(c, aFn, args))))
       .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)))
-      .then(passThrough(notify('CREATE', args)));
+      .then(passThrough(notify(args)));
   };
 };
 

--- a/src/plugins/cache/operations/read.spec.js
+++ b/src/plugins/cache/operations/read.spec.js
@@ -77,7 +77,7 @@ describe('Read', () => {
 
       it('triggers notify when not in cache', () => {
         const spy = sinon.spy();
-        const n = curry((a, b, c) => spy(a, b, c));
+        const n = curry((a, b) => spy(a, b));
         const cache = createCache(config);
         const e = config[0];
         const xOrg = {id: 1, name: 'Kalle'};
@@ -85,13 +85,13 @@ describe('Read', () => {
         const aFn = sinon.spy(aFnWithoutSpy);
         const res = decorateRead({}, cache, n, e, aFn);
         return res(1).then((r) => {
-          expect(spy).to.have.been.calledWith('CREATE', [1], r);
+          expect(spy).to.have.been.calledWith([1], r);
         });
       });
 
       it('does not trigger notify when in cache', () => {
         const spy = sinon.spy();
-        const n = curry((a, b, c) => spy(a, b, c));
+        const n = curry((a, b) => spy(a, b));
         const cache = createCache(config);
         const e = config[0];
         const xOrg = {id: 1, name: 'Kalle'};
@@ -176,20 +176,20 @@ describe('Read', () => {
 
       it('triggers notify when not in cache', () => {
         const spy = sinon.spy();
-        const n = curry((a, b, c) => spy(a, b, c));
+        const n = curry((a, b) => spy(a, b));
         const cache = createCache(config);
         const e = config[0];
         const fnWithSpy = sinon.spy(decoratedFn);
         const apiFn = decorateRead({}, cache, n, e, fnWithSpy);
         return apiFn(['a', 'b']).then((r) => {
           expect(spy).to.have.been.calledOnce;
-          expect(spy).to.have.been.calledWith('CREATE', [['a', 'b']], r);
+          expect(spy).to.have.been.calledWith([['a', 'b']], r);
         });
       });
 
       it('triggers notify when not in cache for partial request', () => {
         const spy = sinon.spy();
-        const n = curry((a, b, c) => spy(a, b, c));
+        const n = curry((a, b) => spy(a, b));
         const cache = createCache(config);
         const e = config[0];
         const fnWithSpy = sinon.spy(decoratedFn);
@@ -198,14 +198,14 @@ describe('Read', () => {
           spy.reset();
           return apiFn(['a', 'b', 'c']).then((r) => {
             expect(spy).to.have.been.calledOnce;
-            expect(spy).to.have.been.calledWith('CREATE', [['c']], r);
+            expect(spy).to.have.been.calledWith([['c']], r);
           });
         });
       });
 
       it('does not trigger notify when in cache', () => {
         const spy = sinon.spy();
-        const n = curry((a, b, c) => spy(a, b, c));
+        const n = curry((a, b) => spy(a, b));
         const cache = createCache(config);
         const e = config[0];
         const fnWithSpy = sinon.spy(decoratedFn);
@@ -326,7 +326,7 @@ describe('Read', () => {
 
     it('triggers notify when not in cache', () => {
       const spy = sinon.spy();
-      const n = curry((a, b, c) => spy(a, b, c));
+      const n = curry((a, b) => spy(a, b));
       const cache = createCache(config);
       const e = config[0];
       const xOrg = [{id: 1, name: 'Kalle'}];
@@ -336,13 +336,13 @@ describe('Read', () => {
 
       return res(1).then((r) => {
         expect(spy).to.have.been.calledOnce;
-        expect(spy).to.have.been.calledWith('CREATE', [1], r);
+        expect(spy).to.have.been.calledWith([1], r);
       });
     });
 
     it('does not trigger notify when in cache', () => {
       const spy = sinon.spy();
-      const n = curry((a, b, c) => spy(a, b, c));
+      const n = curry((a, b) => spy(a, b));
       const cache = createCache(config);
       const e = config[0];
       const xOrg = [{id: 1, name: 'Kalle'}];

--- a/src/plugins/cache/operations/read.spec.js
+++ b/src/plugins/cache/operations/read.spec.js
@@ -23,6 +23,7 @@ describe('Read', () => {
         done();
       });
     });
+
     it('does set id to serialized args if idFrom ARGS', (done) => {
       const cache = createCache(config);
       const e = config[0];
@@ -35,45 +36,51 @@ describe('Read', () => {
         done();
       });
     });
-    it('calls api fn if not in cache with byId set', (done) => {
-      const cache = createCache(config);
-      const e = config[0];
-      const xOrg = {id: 1, name: 'Kalle'};
-      const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg), {byId: true});
-      const aFn = sinon.spy(aFnWithoutSpy);
-      const res = decorateRead({}, cache, curryNoop, e, aFn);
-      res(1).then(() => {
-        expect(aFn.callCount).to.equal(1);
-        done();
+
+    describe('with byId set', () => {
+      it('calls api fn if not in cache', (done) => {
+        const cache = createCache(config);
+        const e = config[0];
+        const xOrg = {id: 1, name: 'Kalle'};
+        const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg), {byId: true});
+        const aFn = sinon.spy(aFnWithoutSpy);
+        const res = decorateRead({}, cache, curryNoop, e, aFn);
+        res(1).then(() => {
+          expect(aFn.callCount).to.equal(1);
+          done();
+        });
+      });
+
+      it('calls api fn if in cache, but expired', (done) => {
+        const myConfig = createSampleConfig();
+        myConfig[0].ttl = 0;
+        const cache = createCache(myConfig);
+        const e = myConfig[0];
+        const xOrg = {id: 1, name: 'Kalle'};
+        const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg), {byId: true});
+        const aFn = sinon.spy(aFnWithoutSpy);
+        const res = decorateRead({}, cache, curryNoop, e, aFn);
+        const delay = () => new Promise((resolve) => setTimeout(resolve, 1));
+        res(1).then(delay).then(res.bind(null, 1)).then(() => {
+          expect(aFn.callCount).to.equal(2);
+          done();
+        });
+      });
+
+      it('does not call api fn if in cache', (done) => {
+        const cache = createCache(config);
+        const e = config[0];
+        const xOrg = {id: 1, name: 'Kalle'};
+        const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg), {byId: true});
+        const aFn = sinon.spy(aFnWithoutSpy);
+        const res = decorateRead({}, cache, curryNoop, e, aFn);
+        res(1).then(res.bind(null, 1)).then(() => {
+          expect(aFn.callCount).to.equal(1);
+          done();
+        });
       });
     });
-    it('calls api fn if in cache, but expired, with byId set', (done) => {
-      const myConfig = createSampleConfig();
-      myConfig[0].ttl = 0;
-      const cache = createCache(myConfig);
-      const e = myConfig[0];
-      const xOrg = {id: 1, name: 'Kalle'};
-      const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg), {byId: true});
-      const aFn = sinon.spy(aFnWithoutSpy);
-      const res = decorateRead({}, cache, curryNoop, e, aFn);
-      const delay = () => new Promise((resolve) => setTimeout(resolve, 1));
-      res(1).then(delay).then(res.bind(null, 1)).then(() => {
-        expect(aFn.callCount).to.equal(2);
-        done();
-      });
-    });
-    it('does not call api fn if in cache with byId set', (done) => {
-      const cache = createCache(config);
-      const e = config[0];
-      const xOrg = {id: 1, name: 'Kalle'};
-      const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg), {byId: true});
-      const aFn = sinon.spy(aFnWithoutSpy);
-      const res = decorateRead({}, cache, curryNoop, e, aFn);
-      res(1).then(res.bind(null, 1)).then(() => {
-        expect(aFn.callCount).to.equal(1);
-        done();
-      });
-    });
+
     describe('with byIds', () => {
       const users = {
         a: { id: 'a' },
@@ -144,6 +151,7 @@ describe('Read', () => {
         });
       });
     });
+
     it('calls api fn if not in cache', (done) => {
       const cache = createCache(config);
       const e = config[0];
@@ -156,6 +164,7 @@ describe('Read', () => {
         done();
       });
     });
+
     it('does not call api fn if in cache', (done) => {
       const cache = createCache(config);
       const e = config[0];
@@ -173,6 +182,7 @@ describe('Read', () => {
         });
       });
     });
+
     it('does call api fn if in cache but expired', (done) => {
       const cache = createCache(config);
       const e = {...config[0], ttl: -1};
@@ -190,6 +200,7 @@ describe('Read', () => {
         });
       });
     });
+
     it('calls api fn if not in cache (plural)', (done) => {
       const cache = createCache(config);
       const e = config[0];
@@ -202,6 +213,7 @@ describe('Read', () => {
         done();
       });
     });
+
     it('does not call api fn if in cache (plural)', (done) => {
       const cache = createCache(config);
       const e = config[0];
@@ -219,6 +231,7 @@ describe('Read', () => {
         });
       });
     });
+
     it('does call api fn if in cache but expired (plural)', (done) => {
       const cache = createCache(config);
       const e = {...config[0], ttl: -1};
@@ -236,6 +249,7 @@ describe('Read', () => {
         });
       });
     });
+
     it('throws if id is missing', (done) => {
       const cache = createCache(config);
       const e = {...config[0], ttl: 300};

--- a/src/plugins/cache/operations/read.spec.js
+++ b/src/plugins/cache/operations/read.spec.js
@@ -11,47 +11,44 @@ const config = createSampleConfig();
 
 describe('Read', () => {
   describe('decorateRead', () => {
-    it('stores and returns an array with elements that lack id', (done) => {
+    it('stores and returns an array with elements that lack id', () => {
       const cache = createCache(config);
       const e = config[0];
       const xOrg = [{name: 'Kalle'}, {name: 'Anka'}];
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg), {idFrom: 'ARGS'});
       const aFn = sinon.spy(aFnWithoutSpy);
       const res = decorateRead({}, cache, curryNoop, e, aFn);
-      res(1).then(x => {
+      return res(1).then(x => {
         expect(x).to.deep.equal(xOrg);
-        done();
       });
     });
 
-    it('does set id to serialized args if idFrom ARGS', (done) => {
+    it('does set id to serialized args if idFrom ARGS', () => {
       const cache = createCache(config);
       const e = config[0];
       const xOrg = {name: 'Kalle'};
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg), {idFrom: 'ARGS'});
       const aFn = sinon.spy(aFnWithoutSpy);
       const res = decorateRead({}, cache, curryNoop, e, aFn);
-      res({hello: 'hej', other: 'svej'}).then(x => {
+      return res({hello: 'hej', other: 'svej'}).then(x => {
         expect(x).to.deep.equal({name: 'Kalle'});
-        done();
       });
     });
 
     describe('with byId set', () => {
-      it('calls api fn if not in cache', (done) => {
+      it('calls api fn if not in cache', () => {
         const cache = createCache(config);
         const e = config[0];
         const xOrg = {id: 1, name: 'Kalle'};
         const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg), {byId: true});
         const aFn = sinon.spy(aFnWithoutSpy);
         const res = decorateRead({}, cache, curryNoop, e, aFn);
-        res(1).then(() => {
+        return res(1).then(() => {
           expect(aFn.callCount).to.equal(1);
-          done();
         });
       });
 
-      it('calls api fn if in cache, but expired', (done) => {
+      it('calls api fn if in cache, but expired', () => {
         const myConfig = createSampleConfig();
         myConfig[0].ttl = 0;
         const cache = createCache(myConfig);
@@ -61,22 +58,20 @@ describe('Read', () => {
         const aFn = sinon.spy(aFnWithoutSpy);
         const res = decorateRead({}, cache, curryNoop, e, aFn);
         const delay = () => new Promise((resolve) => setTimeout(resolve, 1));
-        res(1).then(delay).then(res.bind(null, 1)).then(() => {
+        return res(1).then(delay).then(res.bind(null, 1)).then(() => {
           expect(aFn.callCount).to.equal(2);
-          done();
         });
       });
 
-      it('does not call api fn if in cache', (done) => {
+      it('does not call api fn if in cache', () => {
         const cache = createCache(config);
         const e = config[0];
         const xOrg = {id: 1, name: 'Kalle'};
         const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg), {byId: true});
         const aFn = sinon.spy(aFnWithoutSpy);
         const res = decorateRead({}, cache, curryNoop, e, aFn);
-        res(1).then(res.bind(null, 1)).then(() => {
+        return res(1).then(res.bind(null, 1)).then(() => {
           expect(aFn.callCount).to.equal(1);
-          done();
         });
       });
     });
@@ -152,20 +147,19 @@ describe('Read', () => {
       });
     });
 
-    it('calls api fn if not in cache', (done) => {
+    it('calls api fn if not in cache', () => {
       const cache = createCache(config);
       const e = config[0];
       const xOrg = {id: 1, name: 'Kalle'};
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg));
       const aFn = sinon.spy(aFnWithoutSpy);
       const res = decorateRead({}, cache, curryNoop, e, aFn);
-      res(1).then(() => {
+      return res(1).then(() => {
         expect(aFn.callCount).to.equal(1);
-        done();
       });
     });
 
-    it('does not call api fn if in cache', (done) => {
+    it('does not call api fn if in cache', () => {
       const cache = createCache(config);
       const e = config[0];
       const xOrg = {id: 1, name: 'Kalle'};
@@ -175,15 +169,14 @@ describe('Read', () => {
 
       const firstCall = res(1);
 
-      firstCall.then(() => {
-        res(1).then(() => {
+      return firstCall.then(() => {
+        return res(1).then(() => {
           expect(aFn.callCount).to.equal(1);
-          done();
         });
       });
     });
 
-    it('does call api fn if in cache but expired', (done) => {
+    it('does call api fn if in cache but expired', () => {
       const cache = createCache(config);
       const e = {...config[0], ttl: -1};
       const xOrg = {id: 1, name: 'Kalle'};
@@ -193,28 +186,26 @@ describe('Read', () => {
 
       const firstCall = res(1);
 
-      firstCall.then(() => {
-        res(1).then(() => {
+      return firstCall.then(() => {
+        return res(1).then(() => {
           expect(aFn.callCount).to.equal(2);
-          done();
         });
       });
     });
 
-    it('calls api fn if not in cache (plural)', (done) => {
+    it('calls api fn if not in cache (plural)', () => {
       const cache = createCache(config);
       const e = config[0];
       const xOrg = [{id: 1, name: 'Kalle'}];
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg));
       const aFn = sinon.spy(aFnWithoutSpy);
       const res = decorateRead({}, cache, curryNoop, e, aFn);
-      res(1).then((x) => {
+      return res(1).then((x) => {
         expect(x).to.equal(xOrg);
-        done();
       });
     });
 
-    it('does not call api fn if in cache (plural)', (done) => {
+    it('does not call api fn if in cache (plural)', () => {
       const cache = createCache(config);
       const e = config[0];
       const xOrg = [{id: 1, name: 'Kalle'}];
@@ -224,15 +215,14 @@ describe('Read', () => {
 
       const firstCall = res(1);
 
-      firstCall.then(() => {
-        res(1).then(() => {
+      return firstCall.then(() => {
+        return res(1).then(() => {
           expect(aFn.callCount).to.equal(1);
-          done();
         });
       });
     });
 
-    it('does call api fn if in cache but expired (plural)', (done) => {
+    it('does call api fn if in cache but expired (plural)', () => {
       const cache = createCache(config);
       const e = {...config[0], ttl: -1};
       const xOrg = [{id: 1, name: 'Kalle'}];
@@ -242,15 +232,14 @@ describe('Read', () => {
 
       const firstCall = res(1);
 
-      firstCall.then(() => {
-        res(1).then(() => {
+      return firstCall.then(() => {
+        return res(1).then(() => {
           expect(aFn.callCount).to.equal(2);
-          done();
         });
       });
     });
 
-    it('throws if id is missing', (done) => {
+    it('throws if id is missing', () => {
       const cache = createCache(config);
       const e = {...config[0], ttl: 300};
       const xOrg = {name: 'Kalle'};
@@ -258,9 +247,8 @@ describe('Read', () => {
       const aFn = sinon.spy(aFnWithoutSpy);
       const res = decorateRead({}, cache, curryNoop, e, aFn);
 
-      res().catch(err => {
+      return res().catch(err => {
         expect(err).to.be.a('Error');
-        done();
       });
     });
   });

--- a/src/plugins/cache/operations/read.spec.js
+++ b/src/plugins/cache/operations/read.spec.js
@@ -6,6 +6,7 @@ import {decorateRead} from './read';
 import {createCache} from '../cache';
 import {createSampleConfig, createApiFunction} from '../test-helper';
 
+const curryNoop = () => () => {};
 const config = createSampleConfig();
 
 describe('Read', () => {
@@ -16,7 +17,7 @@ describe('Read', () => {
       const xOrg = [{name: 'Kalle'}, {name: 'Anka'}];
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg), {idFrom: 'ARGS'});
       const aFn = sinon.spy(aFnWithoutSpy);
-      const res = decorateRead({}, cache, e, aFn);
+      const res = decorateRead({}, cache, curryNoop, e, aFn);
       res(1).then(x => {
         expect(x).to.deep.equal(xOrg);
         done();
@@ -28,7 +29,7 @@ describe('Read', () => {
       const xOrg = {name: 'Kalle'};
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg), {idFrom: 'ARGS'});
       const aFn = sinon.spy(aFnWithoutSpy);
-      const res = decorateRead({}, cache, e, aFn);
+      const res = decorateRead({}, cache, curryNoop, e, aFn);
       res({hello: 'hej', other: 'svej'}).then(x => {
         expect(x).to.deep.equal({name: 'Kalle'});
         done();
@@ -40,7 +41,7 @@ describe('Read', () => {
       const xOrg = {id: 1, name: 'Kalle'};
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg), {byId: true});
       const aFn = sinon.spy(aFnWithoutSpy);
-      const res = decorateRead({}, cache, e, aFn);
+      const res = decorateRead({}, cache, curryNoop, e, aFn);
       res(1).then(() => {
         expect(aFn.callCount).to.equal(1);
         done();
@@ -54,7 +55,7 @@ describe('Read', () => {
       const xOrg = {id: 1, name: 'Kalle'};
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg), {byId: true});
       const aFn = sinon.spy(aFnWithoutSpy);
-      const res = decorateRead({}, cache, e, aFn);
+      const res = decorateRead({}, cache, curryNoop, e, aFn);
       const delay = () => new Promise((resolve) => setTimeout(resolve, 1));
       res(1).then(delay).then(res.bind(null, 1)).then(() => {
         expect(aFn.callCount).to.equal(2);
@@ -67,7 +68,7 @@ describe('Read', () => {
       const xOrg = {id: 1, name: 'Kalle'};
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg), {byId: true});
       const aFn = sinon.spy(aFnWithoutSpy);
-      const res = decorateRead({}, cache, e, aFn);
+      const res = decorateRead({}, cache, curryNoop, e, aFn);
       res(1).then(res.bind(null, 1)).then(() => {
         expect(aFn.callCount).to.equal(1);
         done();
@@ -87,7 +88,7 @@ describe('Read', () => {
         const cache = createCache(config);
         const e = config[0];
         const fnWithSpy = sinon.spy(decoratedFn);
-        const apiFn = decorateRead({}, cache, e, fnWithSpy);
+        const apiFn = decorateRead({}, cache, curryNoop, e, fnWithSpy);
         return apiFn(['a', 'b']).then((res) => {
           expect(res).to.deep.equal([users.a, users.b]);
         });
@@ -97,7 +98,7 @@ describe('Read', () => {
         const cache = createCache(config);
         const e = config[0];
         const fnWithSpy = sinon.spy(decoratedFn);
-        const apiFn = decorateRead({}, cache, e, fnWithSpy);
+        const apiFn = decorateRead({}, cache, curryNoop, e, fnWithSpy);
         return apiFn(['a', 'b']).then((res) => {
           expect(res).to.deep.equal([users.a, users.b]);
         });
@@ -107,7 +108,7 @@ describe('Read', () => {
         const cache = createCache(config);
         const e = config[0];
         const fnWithSpy = sinon.spy(decoratedFn);
-        const apiFn = decorateRead({}, cache, e, fnWithSpy);
+        const apiFn = decorateRead({}, cache, curryNoop, e, fnWithSpy);
         const args = ['a', 'b'];
         return apiFn(args).then(() => {
           return apiFn(args).then((res) => {
@@ -121,7 +122,7 @@ describe('Read', () => {
         const cache = createCache(config);
         const e = config[0];
         const fnWithSpy = sinon.spy(decoratedFn);
-        const apiFn = decorateRead({}, cache, e, fnWithSpy);
+        const apiFn = decorateRead({}, cache, curryNoop, e, fnWithSpy);
         return apiFn(['a', 'b']).then(() => {
           return apiFn(['b', 'c']).then(() => {
             expect(fnWithSpy).to.have.been.calledTwice;
@@ -135,7 +136,7 @@ describe('Read', () => {
         const cache = createCache(config);
         const e = config[0];
         const fnWithSpy = sinon.spy(decoratedFn);
-        const apiFn = decorateRead({}, cache, e, fnWithSpy);
+        const apiFn = decorateRead({}, cache, curryNoop, e, fnWithSpy);
         return apiFn(['a', 'b']).then(() => {
           return apiFn(['a', 'b', 'c']).then((res) => {
             expect(res).to.deep.equal([users.a, users.b, users.c]);
@@ -149,7 +150,7 @@ describe('Read', () => {
       const xOrg = {id: 1, name: 'Kalle'};
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg));
       const aFn = sinon.spy(aFnWithoutSpy);
-      const res = decorateRead({}, cache, e, aFn);
+      const res = decorateRead({}, cache, curryNoop, e, aFn);
       res(1).then(() => {
         expect(aFn.callCount).to.equal(1);
         done();
@@ -161,7 +162,7 @@ describe('Read', () => {
       const xOrg = {id: 1, name: 'Kalle'};
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg));
       const aFn = sinon.spy(aFnWithoutSpy);
-      const res = decorateRead({}, cache, e, aFn);
+      const res = decorateRead({}, cache, curryNoop, e, aFn);
 
       const firstCall = res(1);
 
@@ -178,7 +179,7 @@ describe('Read', () => {
       const xOrg = {id: 1, name: 'Kalle'};
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg));
       const aFn = sinon.spy(aFnWithoutSpy);
-      const res = decorateRead({}, cache, e, aFn);
+      const res = decorateRead({}, cache, curryNoop, e, aFn);
 
       const firstCall = res(1);
 
@@ -195,7 +196,7 @@ describe('Read', () => {
       const xOrg = [{id: 1, name: 'Kalle'}];
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg));
       const aFn = sinon.spy(aFnWithoutSpy);
-      const res = decorateRead({}, cache, e, aFn);
+      const res = decorateRead({}, cache, curryNoop, e, aFn);
       res(1).then((x) => {
         expect(x).to.equal(xOrg);
         done();
@@ -207,7 +208,7 @@ describe('Read', () => {
       const xOrg = [{id: 1, name: 'Kalle'}];
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg));
       const aFn = sinon.spy(aFnWithoutSpy);
-      const res = decorateRead({}, cache, e, aFn);
+      const res = decorateRead({}, cache, curryNoop, e, aFn);
 
       const firstCall = res(1);
 
@@ -224,7 +225,7 @@ describe('Read', () => {
       const xOrg = [{id: 1, name: 'Kalle'}];
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg));
       const aFn = sinon.spy(aFnWithoutSpy);
-      const res = decorateRead({}, cache, e, aFn);
+      const res = decorateRead({}, cache, curryNoop, e, aFn);
 
       const firstCall = res(1);
 
@@ -241,7 +242,7 @@ describe('Read', () => {
       const xOrg = {name: 'Kalle'};
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg));
       const aFn = sinon.spy(aFnWithoutSpy);
-      const res = decorateRead({}, cache, e, aFn);
+      const res = decorateRead({}, cache, curryNoop, e, aFn);
 
       res().catch(err => {
         expect(err).to.be.a('Error');

--- a/src/plugins/cache/operations/update.js
+++ b/src/plugins/cache/operations/update.js
@@ -7,6 +7,6 @@ export function decorateUpdate(c, cache, notify, e, aFn) {
     return aFn(eValue, ...args)
       .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)))
       .then(passThrough(() => Cache.storeEntity(cache, e, addId(c, undefined, undefined, eValue))))
-      .then(passThrough(() => notify('UPDATE', [eValue, ...args], eValue)));
+      .then(passThrough(() => notify([eValue, ...args], eValue)));
   };
 }

--- a/src/plugins/cache/operations/update.js
+++ b/src/plugins/cache/operations/update.js
@@ -6,6 +6,7 @@ export function decorateUpdate(c, cache, notify, e, aFn) {
   return (eValue, ...args) => {
     return aFn(eValue, ...args)
       .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)))
-      .then(passThrough(() => Cache.storeEntity(cache, e, addId(c, undefined, undefined, eValue))));
+      .then(passThrough(() => Cache.storeEntity(cache, e, addId(c, undefined, undefined, eValue))))
+      .then(passThrough(() => notify('UPDATE', [eValue, ...args], eValue)));
   };
 }

--- a/src/plugins/cache/operations/update.js
+++ b/src/plugins/cache/operations/update.js
@@ -2,7 +2,7 @@ import {passThrough} from 'ladda-fp';
 import * as Cache from '../cache';
 import {addId} from '../id-helper';
 
-export function decorateUpdate(c, cache, e, aFn) {
+export function decorateUpdate(c, cache, notify, e, aFn) {
   return (eValue, ...args) => {
     return aFn(eValue, ...args)
       .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)))

--- a/src/plugins/cache/operations/update.spec.js
+++ b/src/plugins/cache/operations/update.spec.js
@@ -3,6 +3,8 @@ import {decorateUpdate} from './update';
 import * as Cache from '../cache';
 import {createApiFunction} from '../test-helper';
 
+const curryNoop = () => () => {};
+
 const config = [
   {
     name: 'user',
@@ -46,7 +48,7 @@ describe('Update', () => {
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg));
       const aFn = sinon.spy(aFnWithoutSpy);
 
-      const res = decorateUpdate({}, cache, e, aFn);
+      const res = decorateUpdate({}, cache, curryNoop, e, aFn);
       res(xOrg, 'other args').then(() => {
         expect(Cache.getEntity(cache, e, 1).value).to.deep.equal({...xOrg, __ladda__id: 1});
         done();

--- a/src/plugins/cache/operations/update.spec.js
+++ b/src/plugins/cache/operations/update.spec.js
@@ -59,7 +59,7 @@ describe('Update', () => {
 
     it('triggers an UPDATE notification', () => {
       const spy = sinon.spy();
-      const n = curry((a, b, c) => spy(a, b, c));
+      const n = curry((a, b) => spy(a, b));
 
       const cache = Cache.createCache(config);
       const e = config[0];
@@ -70,7 +70,7 @@ describe('Update', () => {
       const res = decorateUpdate({}, cache, n, e, aFn);
       return res(xOrg, 'other args').then(() => {
         expect(spy).to.have.been.calledOnce;
-        expect(spy).to.have.been.calledWith('UPDATE', [xOrg, 'other args'], xOrg);
+        expect(spy).to.have.been.calledWith([xOrg, 'other args'], xOrg);
       });
     });
   });


### PR DESCRIPTION
- Calls dedup at the beginning and at the end of the plugin chain for a maximum effect
- Moves the onChange hook out of the EntityStore, which doesn't have this odd side effect anymore. Operations trigger the notification now, which also allows us to provide more information (e.g. about the function which has triggered the change!)