### PR TITLE
Feat/notify from outside

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -128,13 +128,13 @@ const applyPlugin = curry((addChangeListener, config, entityConfigs, plugin) => 
 });
 
 // Config -> Api
-export const build = (c, ps = []) => {
-  const config = getGlobalConfig(c);
-  const entityConfigs = getEntityConfigs(c);
-  validateConfig(console, entityConfigs, config);
-  const listenerStore = createListenerStore(config);
-  const applyPlugin_ = applyPlugin(listenerStore.addChangeListener, config);
+export const build = (config, plugins = []) => {
+  const globalConfig = getGlobalConfig(config);
+  const entityConfigs = getEntityConfigs(config);
+  validateConfig(console, entityConfigs, globalConfig);
+  const listenerStore = createListenerStore(globalConfig);
+  const applyPlugin_ = applyPlugin(listenerStore.addChangeListener, globalConfig);
   const applyPlugins = reduce(applyPlugin_, entityConfigs);
   const createApi = compose(toApi, applyPlugins);
-  return createApi([cachePlugin(listenerStore.onChange), ...ps, dedupPlugin]);
+  return createApi([cachePlugin(listenerStore.onChange), ...plugins, dedupPlugin]);
 };

--- a/src/builder.js
+++ b/src/builder.js
@@ -106,12 +106,34 @@ const setApiConfigDefaults = ec => {
   };
 };
 
+const createNotifyFunction = (operation) => {
+  const fn = (x) => Promise.resolve(x);
+  fn.operation = operation;
+  fn.isNotifier = true;
+  fn.invalidates = [];
+  return fn;
+};
+
+const addNotifyFunctions = (entityConfig) => {
+  if (!entityConfig.api) {
+    entityConfig.api = {};
+  }
+
+  entityConfig.api._notifyCreate = createNotifyFunction('CREATE');
+  entityConfig.api._notifyRead = createNotifyFunction('READ');
+  entityConfig.api._notifyUpdate = createNotifyFunction('UPDATE');
+  entityConfig.api._notifyDelete = createNotifyFunction('DELETE');
+
+  return entityConfig;
+};
+
 // Config -> Map String EntityConfig
-export const getEntityConfigs = compose( // exported for testing
+export const createEntityConfigs = compose( // exported for testing
   toObject(prop('name')),
   mapObject(toEntity),
   mapValues(setApiConfigDefaults),
   mapValues(setEntityConfigDefaults),
+  mapValues(addNotifyFunctions),
   filterObject(compose(not, isEqual('__config')))
 );
 
@@ -130,7 +152,7 @@ const applyPlugin = curry((addChangeListener, config, entityConfigs, plugin) => 
 // Config -> Api
 export const build = (config, plugins = []) => {
   const globalConfig = getGlobalConfig(config);
-  const entityConfigs = getEntityConfigs(config);
+  const entityConfigs = createEntityConfigs(config);
   validateConfig(console, entityConfigs, globalConfig);
   const listenerStore = createListenerStore(globalConfig);
   const applyPlugin_ = applyPlugin(listenerStore.addChangeListener, globalConfig);

--- a/src/plugins/cache/index.js
+++ b/src/plugins/cache/index.js
@@ -11,13 +11,22 @@ const HANDLERS = {
   READ: decorateRead,
   UPDATE: decorateUpdate,
   DELETE: decorateDelete,
-  NO_OPERATION: decorateNoOperation
+  NO_OPERATION: decorateNoOperation,
+  NOTIFIER: decorateNoOperation
+};
+
+const getHandler = (fn) => {
+  if (fn.isNotifier === true) {
+    return HANDLERS.NOTIFIER;
+  }
+
+  return HANDLERS[fn.operation];
 };
 
 export const cachePlugin = (onChange) => ({ config, entityConfigs }) => {
   const cache = createCache(values(entityConfigs), onChange);
   return ({ entity, fn }) => {
-    const handler = HANDLERS[fn.operation];
+    const handler = getHandler(fn);
     return handler(config, cache, entity, fn);
   };
 };

--- a/src/plugins/cache/operations/notifier.js
+++ b/src/plugins/cache/operations/notifier.js
@@ -1,0 +1,9 @@
+import {passThrough} from 'ladda-fp';
+import {invalidateQuery} from '../cache';
+
+export function decorateNotifier(c, cache, e, aFn) {
+  return (...args) => {
+    return aFn(...args)
+          .then(passThrough(() => invalidateQuery(cache, e, aFn)));
+  };
+}

--- a/src/plugins/cache/operations/notifier.spec.js
+++ b/src/plugins/cache/operations/notifier.spec.js
@@ -1,0 +1,62 @@
+/* eslint-disable no-unused-expressions */
+
+import sinon from 'sinon';
+import {decorateNotifier} from './notifier';
+import * as Cache from '../cache';
+import {createSampleConfig} from '../test-helper';
+
+const config = createSampleConfig();
+
+describe('DecorateNotifier', () => {
+  it('Invalidates as if it was the specified operation', (done) => {
+    const cache = Cache.createCache(config);
+    const e = config[0];
+    e.invalidatesOn = ['READ'];
+    const xOrg = {__ladda__id: 1, name: 'Kalle'};
+    const aFn = sinon.spy(() => Promise.resolve({}));
+    const getUsers = () => Promise.resolve(xOrg);
+    aFn.operation = 'READ';
+    aFn.isNotifier = true;
+    aFn.invalidates = [];
+    Cache.storeQueryResponse(cache, e, getUsers, ['args'], xOrg);
+    const res = decorateNotifier({}, cache, e, aFn);
+    res(xOrg).then(() => {
+      const killedCache = !Cache.containsQueryResponse(cache, e, getUsers, ['args']);
+      expect(killedCache).to.be.true;
+      done();
+    });
+  });
+  it('Does not invalidate if operation does not cause invalidation', (done) => {
+    const cache = Cache.createCache(config);
+    const e = config[0];
+    e.invalidatesOn = ['READ'];
+    const xOrg = {__ladda__id: 1, name: 'Kalle'};
+    const aFn = sinon.spy(() => Promise.resolve({}));
+    const getUsers = () => Promise.resolve(xOrg);
+    aFn.operation = 'DELETE';
+    aFn.isNotifier = true;
+    aFn.invalidates = [];
+    Cache.storeQueryResponse(cache, e, getUsers, ['args'], xOrg);
+    const res = decorateNotifier({}, cache, e, aFn);
+    res(xOrg).then(() => {
+      const killedCache = !Cache.containsQueryResponse(cache, e, getUsers, ['args']);
+      expect(killedCache).to.be.false;
+      done();
+    });
+  });
+  it('Does not write to cache', (done) => {
+    const cache = Cache.createCache(config);
+    const e = config[0];
+    const xOrg = {__ladda__id: 1, name: 'Kalle'};
+    const aFn = sinon.spy(() => Promise.resolve({}));
+    aFn.operation = 'CREATE';
+    aFn.isNotifier = false;
+    aFn.invalidates = [];
+    const res = decorateNotifier({}, cache, e, aFn);
+    res(xOrg).then(() => {
+      const hasEntity = Cache.containsEntity(cache, e, 1);
+      expect(hasEntity).to.be.false;
+      done();
+    });
+  });
+});

--- a/src/validator.spec.js
+++ b/src/validator.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 import sinon from 'sinon';
 import { validateConfig } from './validator';
-import { getEntityConfigs } from './builder';
+import { createEntityConfigs } from './builder';
 
 const createLogger = () => ({
   error: sinon.spy()
@@ -17,7 +17,7 @@ const createGlobalConfig = (conf) => ({
 describe('validateConfig', () => {
   it('does not do anything when using production build', () => {
     const logger = createLogger();
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {}
     });
     const config = createGlobalConfig({ useProductionBuild: true });
@@ -29,7 +29,7 @@ describe('validateConfig', () => {
   it('does not do anything when invalid logger is passed', () => {
     const invalidLogger = { x: sinon.spy() };
 
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {}
     });
     const config = createGlobalConfig({ useProductionBuild: true });
@@ -41,7 +41,7 @@ describe('validateConfig', () => {
   it('checks the global config object - idField', () => {
     const logger = createLogger();
 
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {
         api: {
           getAll: () => {}
@@ -58,7 +58,7 @@ describe('validateConfig', () => {
   it('checks the global config object - enableDeduplication', () => {
     const logger = createLogger();
 
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {
         api: {
           getAll: () => {}
@@ -72,28 +72,10 @@ describe('validateConfig', () => {
     expect(logger.error.args[0][0]).to.match(/enableDeduplication.*boolean.*was.*string/);
   });
 
-  it('checks for missing api declarations', () => {
-    const logger = createLogger();
-
-    const eConfigs = getEntityConfigs({
-      user: {
-        api: {
-          getAll: () => {}
-        }
-      },
-      activity: {}
-    });
-    const config = createGlobalConfig({});
-
-    validateConfig(logger, eConfigs, config);
-    expect(logger.error).to.have.been.called;
-    expect(logger.error.args[0][0]).to.match(/No api definition.*activity/);
-  });
-
   it('checks for non-configured views', () => {
     const logger = createLogger();
 
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {
         api: {
           getAll: () => {}
@@ -122,7 +104,7 @@ describe('validateConfig', () => {
   it('checks for wrong invalidation targets', () => {
     const logger = createLogger();
 
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {
         api: { getAll: () => {} },
         invalidates: ['activity', 'ntification'] // typo!
@@ -146,7 +128,7 @@ describe('validateConfig', () => {
   it('checks for wrong invalidation operations', () => {
     const logger = createLogger();
 
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {
         api: { getAll: () => {} }
       },
@@ -170,7 +152,7 @@ describe('validateConfig', () => {
   it('checks for wrong ttl values', () => {
     const logger = createLogger();
 
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {
         api: { getAll: () => {} },
         ttl: 300
@@ -190,7 +172,7 @@ describe('validateConfig', () => {
   it('checks for wrong enableDeduplication value', () => {
     const logger = createLogger();
 
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {
         api: { getAll: () => {} },
         enableDeduplication: true
@@ -216,7 +198,7 @@ describe('validateConfig', () => {
     const getAll = () => {};
     getAll.operation = 'X';
 
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {
         api: { getAll }
       }
@@ -235,7 +217,7 @@ describe('validateConfig', () => {
     getAll.operation = 'READ';
     getAll.byId = 'xxx';
 
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {
         api: { getAll }
       }
@@ -254,7 +236,7 @@ describe('validateConfig', () => {
     getAll.operation = 'READ';
     getAll.byIds = 'xxx';
 
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {
         api: { getAll }
       }
@@ -273,7 +255,7 @@ describe('validateConfig', () => {
     getAll.operation = 'READ';
     getAll.enableDeduplication = 'X';
 
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {
         api: { getAll }
       }
@@ -292,7 +274,7 @@ describe('validateConfig', () => {
     getAll.operation = 'READ';
     getAll.idFrom = true;
 
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {
         api: { getAll }
       }
@@ -311,7 +293,7 @@ describe('validateConfig', () => {
     getAll.operation = 'READ';
     getAll.idFrom = 'X';
 
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {
         api: { getAll }
       }
@@ -336,7 +318,7 @@ describe('validateConfig', () => {
     const getSome = () => {};
     getSome.operation = 'READ';
 
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {
         api: { getAll, getSome, getOne }
       }
@@ -355,7 +337,7 @@ describe('validateConfig', () => {
     getAll.operation = 'READ';
     getAll.idFrom = 'X';
 
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {
         api: { getAll },
         invalidates: ['X']
@@ -374,7 +356,7 @@ describe('validateConfig', () => {
     getAll.operation = 'READ';
     getAll.idFrom = 'ENTITY';
 
-    const eConfigs = getEntityConfigs({
+    const eConfigs = createEntityConfigs({
       user: {
         api: { getAll },
         invalidates: ['activity']


### PR DESCRIPTION
Adds notifier functions, functions that do not modify the cache, but can be used to trigger invalidation.

_notifyCreate
_notifyRead
_notifyUpdate
_notifyDelete

which will invalidate based on what is specified in an entity config. For eg. calling _notifyRead in { invalidates: ['user'], invalidatesOn: ['READ'], api: apiFns } would invalidate "user".

This allows the users to model their invalidation logic in Ladda and use it before they use Ladda for all API calls. A possible next step would be to allow the users to override the notify functions with their own implementations, that can also be configured on an API function level (eg. invalidate another api function). This might not be necessary though, since most of the time NO_OPERATION can be used for this.