### PR TITLE
Add COMMAND operation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ladda-cache",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Data fetching layer with support for caching",
   "main": "dist/bundle.js",
   "dependencies": {

--- a/src/plugins/cache/index.js
+++ b/src/plugins/cache/index.js
@@ -4,6 +4,7 @@ import {decorateCreate} from './operations/create';
 import {decorateRead} from './operations/read';
 import {decorateUpdate} from './operations/update';
 import {decorateDelete} from './operations/delete';
+import {decorateCommand} from './operations/command';
 import {decorateNoOperation} from './operations/no-operation';
 
 const HANDLERS = {
@@ -11,6 +12,7 @@ const HANDLERS = {
   READ: decorateRead,
   UPDATE: decorateUpdate,
   DELETE: decorateDelete,
+  COMMAND: decorateCommand,
   NO_OPERATION: decorateNoOperation
 };
 

--- a/src/plugins/cache/operations/command.js
+++ b/src/plugins/cache/operations/command.js
@@ -1,0 +1,13 @@
+import {passThrough} from 'ladda-fp';
+import * as Cache from '../cache';
+import {addId} from '../id-helper';
+
+export function decorateCommand(c, cache, notify, e, aFn) {
+  return (...args) => {
+    return aFn(...args)
+      .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)))
+      .then(passThrough((o) => Cache.storeEntity(cache, e, addId(c, undefined, undefined, o))))
+      .then(passThrough((o) => notify([...args], o)));
+  };
+}
+

--- a/src/plugins/cache/operations/command.spec.js
+++ b/src/plugins/cache/operations/command.spec.js
@@ -1,0 +1,77 @@
+/* eslint-disable no-unused-expressions */
+
+import sinon from 'sinon';
+import {curry} from 'ladda-fp';
+import {decorateCommand} from './command';
+import * as Cache from '../cache';
+import {createApiFunction} from '../test-helper';
+
+const curryNoop = () => () => {};
+
+const config = [
+  {
+    name: 'user',
+    ttl: 300,
+    api: {
+      getUsers: (x) => x,
+      deleteUser: (x) => x
+    },
+    invalidates: ['user'],
+    invalidatesOn: ['GET']
+  },
+  {
+    name: 'userPreview',
+    ttl: 200,
+    api: {
+      getPreviews: (x) => x,
+      updatePreview: (x) => x
+    },
+    invalidates: ['fda'],
+    viewOf: 'user'
+  },
+  {
+    name: 'listUser',
+    ttl: 200,
+    api: {
+      getPreviews: (x) => x,
+      updatePreview: (x) => x
+    },
+    invalidates: ['fda'],
+    viewOf: 'user'
+  }
+];
+
+describe('Command', () => {
+  describe('decorateCommand', () => {
+    it('Updates cache based on return value', () => {
+      const cache = Cache.createCache(config);
+      const e = config[0];
+      const xOrg = {id: 1, name: 'Kalle'};
+      const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg));
+      const aFn = sinon.spy(aFnWithoutSpy);
+
+      const res = decorateCommand({}, cache, curryNoop, e, aFn);
+      return res('an arg', 'other args').then((nextXOrg) => {
+        expect(Cache.getEntity(cache, e, 1).value).to.deep.equal({...nextXOrg, __ladda__id: 1});
+      });
+    });
+
+    it('triggers an UPDATE notification', () => {
+      const spy = sinon.spy();
+      const n = curry((a, b) => spy(a, b));
+
+      const cache = Cache.createCache(config);
+      const e = config[0];
+      const xOrg = {id: 1, name: 'Kalle'};
+      const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg));
+      const aFn = sinon.spy(aFnWithoutSpy);
+
+      const res = decorateCommand({}, cache, n, e, aFn);
+      return res('an arg', 'other args').then((nextXOrg) => {
+        expect(spy).to.have.been.calledOnce;
+        expect(spy).to.have.been.calledWith(['an arg', 'other args'], nextXOrg);
+      });
+    });
+  });
+});
+

--- a/src/plugins/cache/operations/command.spec.js
+++ b/src/plugins/cache/operations/command.spec.js
@@ -18,26 +18,6 @@ const config = [
     },
     invalidates: ['user'],
     invalidatesOn: ['GET']
-  },
-  {
-    name: 'userPreview',
-    ttl: 200,
-    api: {
-      getPreviews: (x) => x,
-      updatePreview: (x) => x
-    },
-    invalidates: ['fda'],
-    viewOf: 'user'
-  },
-  {
-    name: 'listUser',
-    ttl: 200,
-    api: {
-      getPreviews: (x) => x,
-      updatePreview: (x) => x
-    },
-    invalidates: ['fda'],
-    viewOf: 'user'
   }
 ];
 


### PR DESCRIPTION
Adds a new operation called `COMMAND` which is very similar to `UPDATE`, which one crucial difference: While `UPDATE` requires an updated entity as first argument is is agnostic about the resolved value which is returned, `COMMAND` is agnostic about its arguments and only cares about what is returned.

This should help when dealing with a less REST oriented API - you can just pass a command to it and the server's response will update the cache then.

Documentation is not updated yet.