### PR TITLE
Update on create

### DIFF
--- a/src/builder.spec.js
+++ b/src/builder.spec.js
@@ -296,4 +296,36 @@ describe('builder', () => {
       });
     });
   });
+
+  describe('updateOnCreate', () => {
+    it('allows to define a hook, which updates the query cache on create', () => {
+      const xs = [{ id: 1 }, { id: 2 }];
+
+      const createX = (newX) => Promise.resolve(newX);
+      createX.operation = 'CREATE';
+
+      const getXs = () => Promise.resolve(xs);
+      getXs.operation = 'READ';
+      getXs.updateOnCreate = (args, newX, cachedXs) => {
+        return args[0] ? [newX, ...cachedXs] : [...cachedXs, newX]
+      }
+
+      const api = build({ x: { api: { getXs, createX } } });
+
+      return Promise.all([
+        api.x.getXs(true),
+        api.x.getXs(false)
+      ]).then(() => {
+        return api.x.createX({ id: 3 }).then((nextX) => {
+          return Promise.all([
+            api.x.getXs(true),
+            api.x.getXs(false)
+          ]).then(([prepended, appended]) => {
+            expect(prepended).to.deep.equal([nextX, ...xs]);
+            expect(appended).to.deep.equal([...xs, nextX]);
+          });
+        });
+      });
+    });
+  });
 });

--- a/src/builder.spec.js
+++ b/src/builder.spec.js
@@ -327,5 +327,51 @@ describe('builder', () => {
         });
       });
     });
+
+    it('can decide how to update based on prior arguments', () => {
+      const xs = [{ id: 1 }, { id: 2 }];
+
+      const createX = (newX) => Promise.resolve(newX);
+      createX.operation = 'CREATE';
+
+      const getXs = () => Promise.resolve(xs);
+      getXs.operation = 'READ';
+      getXs.updateOnCreate = (args, newX, cachedXs) => [...cachedXs, newX];
+
+      const api = build({ x: { api: { getXs, createX } } });
+
+      return api.x.getXs().then((cachedXs) => {
+        expect(cachedXs).to.deep.equal(xs);
+
+        return api.x.createX({ id: 3 }).then((nextX) => {
+          return api.x.getXs().then((nextXs) => {
+            expect(nextXs).to.deep.equal([...xs, nextX]);
+          });
+        })
+      });
+    });
+
+    it('can decide not to update anything', () => {
+      const xs = [{ id: 1 }, { id: 2 }];
+
+      const createX = (newX) => Promise.resolve(newX);
+      createX.operation = 'CREATE';
+
+      const getXs = () => Promise.resolve(xs);
+      getXs.operation = 'READ';
+      getXs.updateOnCreate = (args, newX, cachedXs) => {}
+
+      const api = build({ x: { api: { getXs, createX } } });
+
+      return api.x.getXs().then((cachedXs) => {
+        expect(cachedXs).to.deep.equal(xs);
+
+        return api.x.createX({ id: 3 }).then((nextX) => {
+          return api.x.getXs().then((nextXs) => {
+            expect(nextXs).to.deep.equal(xs);
+          });
+        })
+      });
+    });
   });
 });

--- a/src/plugins/cache/cache.js
+++ b/src/plugins/cache/cache.js
@@ -28,7 +28,11 @@ export const invalidateQuery = ({queryCache}, ...args) => {
 
 export const hasExpired = ({queryCache}, ...args) => {
   return QueryCache.hasExpired(queryCache, ...args);
-}
+};
+
+export const storeCreateEvent = curry(({queryCache}, entity, id) => {
+  return QueryCache.storeCreateEvent(queryCache, entity, id);
+});
 
 export const storeEntity = curry(({entityStore}, ...args) => {
   return EntityStore.put(entityStore, ...args);

--- a/src/plugins/cache/cache.js
+++ b/src/plugins/cache/cache.js
@@ -26,6 +26,10 @@ export const invalidateQuery = ({queryCache}, ...args) => {
   return QueryCache.invalidate(queryCache, ...args);
 };
 
+export const hasExpired = ({queryCache}, ...args) => {
+  return QueryCache.hasExpired(queryCache, ...args);
+}
+
 export const storeEntity = curry(({entityStore}, ...args) => {
   return EntityStore.put(entityStore, ...args);
 });
@@ -45,3 +49,4 @@ export const removeEntity = ({entityStore}, ...args) => {
 export const containsEntity = ({entityStore}, ...args) => {
   return EntityStore.contains(entityStore, ...args);
 };
+

--- a/src/plugins/cache/id-helper.js
+++ b/src/plugins/cache/id-helper.js
@@ -8,6 +8,13 @@ const getIdGetter = (c, aFn) => {
   return prop(c.idField || 'id');
 };
 
+export const getId = curry((c, aFn, args, o) => {
+  if (aFn && aFn.idFrom === 'ARGS') {
+    return serialize(args);
+  }
+  return getIdGetter(c, aFn)(o);
+});
+
 export const addId = curry((c, aFn, args, o) => {
   if (aFn && aFn.idFrom === 'ARGS') {
     return {
@@ -15,16 +22,16 @@ export const addId = curry((c, aFn, args, o) => {
       __ladda__id: serialize(args)
     };
   }
-  const getId = getIdGetter(c, aFn);
+  const getId_ = getIdGetter(c, aFn);
   if (Array.isArray(o)) {
     return map(x => ({
       ...x,
-      __ladda__id: getId(x)
+      __ladda__id: getId_(x)
     }), o);
   }
   return {
     ...o,
-    __ladda__id: getId(o)
+    __ladda__id: getId_(o)
   };
 });
 

--- a/src/plugins/cache/operations/create.js
+++ b/src/plugins/cache/operations/create.js
@@ -1,12 +1,13 @@
 import {passThrough, compose} from 'ladda-fp';
-import {storeEntity, invalidateQuery} from '../cache';
-import {addId} from '../id-helper';
+import {storeEntity, storeCreateEvent, invalidateQuery} from '../cache';
+import {addId, getId} from '../id-helper';
 
 export function decorateCreate(c, cache, notify, e, aFn) {
   return (...args) => {
     return aFn(...args)
       .then(passThrough(() => invalidateQuery(cache, e, aFn)))
       .then(passThrough(compose(storeEntity(cache, e), addId(c, aFn, args))))
+      .then(passThrough(compose(storeCreateEvent(cache, e), getId(c, aFn, args))))
       .then(passThrough(notify(args)));
   };
 }

--- a/src/plugins/cache/operations/read.js
+++ b/src/plugins/cache/operations/read.js
@@ -2,17 +2,11 @@ import {passThrough, compose, curry, reduce, toIdMap, map, concat, zip} from 'la
 import * as Cache from '../cache';
 import {addId, removeId} from '../id-helper';
 
-const getTtl = e => e.ttl * 1000;
-
-// Entity -> Int -> Bool
-const hasExpired = (e, timestamp) => {
-  return (Date.now() - timestamp) > getTtl(e);
-};
-
 const readFromCache = curry((cache, e, aFn, id) => {
   if (Cache.containsEntity(cache, e, id) && !aFn.alwaysGetFreshData) {
     const v = Cache.getEntity(cache, e, id);
-    if (!hasExpired(e, v.timestamp)) {
+    console.log(Cache.hasExpired);
+    if (!Cache.hasExpired(cache, e, v)) {
       return removeId(v.value);
     }
   }
@@ -67,7 +61,7 @@ const decorateReadQuery = (c, cache, notify, e, aFn) => {
   return (...args) => {
     if (Cache.containsQueryResponse(cache, e, aFn, args) && !aFn.alwaysGetFreshData) {
       const v = Cache.getQueryResponseWithMeta(cache, e, aFn, args);
-      if (!hasExpired(e, v.timestamp)) {
+      if (!Cache.hasExpired(cache, e, v)) {
         return Promise.resolve(removeId(Cache.getQueryResponse(v.value)));
       }
     }

--- a/src/plugins/cache/operations/read.js
+++ b/src/plugins/cache/operations/read.js
@@ -5,7 +5,6 @@ import {addId, removeId} from '../id-helper';
 const readFromCache = curry((cache, e, aFn, id) => {
   if (Cache.containsEntity(cache, e, id) && !aFn.alwaysGetFreshData) {
     const v = Cache.getEntity(cache, e, id);
-    console.log(Cache.hasExpired);
     if (!Cache.hasExpired(cache, e, v)) {
       return removeId(v.value);
     }
@@ -60,7 +59,7 @@ const decorateReadSome = (c, cache, notify, e, aFn) => {
 const decorateReadQuery = (c, cache, notify, e, aFn) => {
   return (...args) => {
     if (Cache.containsQueryResponse(cache, e, aFn, args) && !aFn.alwaysGetFreshData) {
-      const v = Cache.getQueryResponseWithMeta(cache, e, aFn, args);
+      const v = Cache.getQueryResponseWithMeta(cache, c, e, aFn, args);
       if (!Cache.hasExpired(cache, e, v)) {
         return Promise.resolve(removeId(Cache.getQueryResponse(v.value)));
       }

--- a/src/plugins/cache/query-cache.js
+++ b/src/plugins/cache/query-cache.js
@@ -107,7 +107,7 @@ export const get = (qc, c, e, aFn, args) => {
     const cachedValue = getFromCache(qc, e, k);
     const entityValue = getFromEs(qc.entityStore, e, id);
     if (!entityValue) {
-      // the item could have been deleted in the meantime
+      // the item might have been deleted in the meantime
       continue; // eslint-disable-line no-continue
     }
     const getVal = compose(removeId, getValue);

--- a/src/plugins/cache/query-cache.js
+++ b/src/plugins/cache/query-cache.js
@@ -56,6 +56,12 @@ export const contains = (qc, e, aFn, args) => {
   return inCache(qc, k);
 };
 
+// Entity -> Milliseconds
+const getTtl = e => e.ttl * 1000;
+
+// QueryCache -> Entity -> CacheValue -> Bool
+export const hasExpired = (qc, e, cv) => (Date.now() - cv.timestamp) > getTtl(e);
+
 // QueryCache -> Entity -> ApiFunction -> [a] -> Bool
 export const get = (qc, e, aFn, args) => {
   const k = createKey(e, [aFn.fnName, ...filter(identity, args)]);

--- a/src/plugins/cache/query-cache.js
+++ b/src/plugins/cache/query-cache.js
@@ -12,7 +12,7 @@ import {serialize} from './serializer';
 const createKey = on2(reduce(join('-')), prop('name'), map(serialize));
 
 // Value -> CacheValue
-const toCacheValue = xs => ({value: xs, timestamp: Date.now()});
+const toCacheValue = (args, xs) => ({value: xs, args, timestamp: Date.now()});
 
 // CacheValue -> Value
 const toValue = prop('value');
@@ -37,9 +37,9 @@ const getFromCache = (qc, e, k) => {
 export const put = curry((qc, e, aFn, args, xs) => {
   const k = createKey(e, [aFn.fnName, ...filter(identity, args)]);
   if (Array.isArray(xs)) {
-    qc.cache[k] = toCacheValue(map(prop('__ladda__id'), xs));
+    qc.cache[k] = toCacheValue(args, map(prop('__ladda__id'), xs));
   } else {
-    qc.cache[k] = toCacheValue(prop('__ladda__id', xs));
+    qc.cache[k] = toCacheValue(args, prop('__ladda__id', xs));
   }
   mPutInEs(qc.entityStore, e, Array.isArray(xs) ? xs : [xs]);
   return xs;

--- a/src/plugins/cache/query-cache.js
+++ b/src/plugins/cache/query-cache.js
@@ -106,15 +106,20 @@ export const get = (qc, c, e, aFn, args) => {
     const id = plainCacheValue.createEvents.shift();
     const cachedValue = getFromCache(qc, e, k);
     const entityValue = getFromEs(qc.entityStore, e, id);
+    if (!entityValue) {
+      // the item could have been deleted in the meantime
+      continue; // eslint-disable-line no-continue
+    }
     const getVal = compose(removeId, getValue);
     const nextEntities = aFn.updateOnCreate(args, getVal(entityValue), getVal(cachedValue.value));
-    if (nextEntities) {
-      const nextCachedValue = compose(
-        (xs) => toCacheValue(map(prop('__ladda__id'), xs, plainCacheValue.createEvents)),
-        addId(c, aFn, args)
-      )(nextEntities);
-      qc.cache[k] = nextCachedValue;
+    if (!nextEntities) {
+      continue; // eslint-disable-line no-continue
     }
+    const nextCachedValue = compose(
+      (xs) => toCacheValue(map(prop('__ladda__id'), xs, plainCacheValue.createEvents)),
+      addId(c, aFn, args)
+    )(nextEntities);
+    qc.cache[k] = nextCachedValue;
   }
   return getFromCache(qc, e, k);
 };

--- a/src/plugins/cache/query-cache.spec.js
+++ b/src/plugins/cache/query-cache.spec.js
@@ -77,7 +77,7 @@ describe('QueryCache', () => {
       const xs = [{id: 1}, {id: 2}, {id: 3}];
       const xsRet = [{id: 1, __ladda__id: 1}, {id: 2, __ladda__id: 2}, {id: 3, __ladda__id: 3}];
       put(qc, e, aFn, args, addId({}, undefined, undefined, xs));
-      expect(getValue(get(qc, e, aFn, args).value)).to.deep.equal(xsRet);
+      expect(getValue(get(qc, undefined, e, aFn, args).value)).to.deep.equal(xsRet);
     });
     it('if an does not exist, throw an error', () => {
       const es = createEntityStore(config);


### PR DESCRIPTION
Adds possibility to manipulate query caches on create by specifying a function "updateOnCreate" on the api function.