### PR TITLE
Fix idFromArgs when no args are given and when they contain empty strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ladda-cache",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "Data fetching layer with support for caching",
   "main": "dist/bundle.js",
   "dependencies": {

--- a/src/builder.spec.js
+++ b/src/builder.spec.js
@@ -519,7 +519,12 @@ describe('builder', () => {
   });
 
   describe('idFrom ARGS', () => {
-    const getX = () => Promise.resolve({ x: 'x' });
+    const getX = (a, b) => {
+      if (a === '' && b === '') {
+        return Promise.resolve({ x: 'xxx' });
+      }
+      return Promise.resolve({ x: 'x' });
+    };
     getX.operation = 'READ';
     getX.idFrom = 'ARGS';
 
@@ -548,6 +553,18 @@ describe('builder', () => {
 
       return api.x.getX().then((x) => {
         expect(x.x).to.equal('x'); // we basically just wanna know it doesn't throw
+      });
+    });
+
+    it('deals properly with empty strings', () => {
+      const c = idFromArgsConfig();
+      const api = build(c);
+
+      return api.x.getX('').then((x) => {
+        expect(x.x).to.equal('x');
+        return api.x.getX('', '').then((secondX) => {
+          expect(secondX.x).to.equal('xxx');
+        });
       });
     });
   });

--- a/src/builder.spec.js
+++ b/src/builder.spec.js
@@ -542,7 +542,7 @@ describe('builder', () => {
       });
     });
 
-    fit('works when return value has no id and NO args are present', () => {
+    it('works when return value has no id and NO args are present', () => {
       const c = idFromArgsConfig();
       const api = build(c);
 

--- a/src/builder.spec.js
+++ b/src/builder.spec.js
@@ -517,4 +517,39 @@ describe('builder', () => {
       });
     });
   });
+
+  describe('idFrom ARGS', () => {
+    const getX = () => Promise.resolve({ x: 'x' });
+    getX.operation = 'READ';
+    getX.idFrom = 'ARGS';
+
+    const idFromArgsConfig = () => ({
+      x: {
+        ttl: 300,
+        api: { getX }
+      },
+      __config: {
+        useProductionBuild: true
+      }
+    });
+
+    it('works when return value has no id and args are present', () => {
+      const c = idFromArgsConfig();
+      const api = build(c);
+
+      return api.x.getX('some', 'random', false, 'args').then((x) => {
+        expect(x.x).to.equal('x'); // we basically just wanna know it doesn't throw
+      });
+    });
+
+    fit('works when return value has no id and NO args are present', () => {
+      const c = idFromArgsConfig();
+      const api = build(c);
+
+      return api.x.getX().then((x) => {
+        expect(x.x).to.equal('x'); // we basically just wanna know it doesn't throw
+      });
+    });
+  });
 });
+

--- a/src/plugins/cache/id-helper.js
+++ b/src/plugins/cache/id-helper.js
@@ -1,6 +1,10 @@
 import {curry, map, prop} from 'ladda-fp';
 import {serialize} from './serializer';
 
+export const EMPTY_ARGS_PLACEHOLDER = '__EMPTY_ARGS__';
+
+const createIdFromArgs = (args) => serialize(args) || EMPTY_ARGS_PLACEHOLDER;
+
 const getIdGetter = (c, aFn) => {
   if (aFn && aFn.idFrom && typeof aFn.idFrom === 'function') {
     return aFn.idFrom;
@@ -10,7 +14,7 @@ const getIdGetter = (c, aFn) => {
 
 export const getId = curry((c, aFn, args, o) => {
   if (aFn && aFn.idFrom === 'ARGS') {
-    return serialize(args);
+    return createIdFromArgs(args);
   }
   return getIdGetter(c, aFn)(o);
 });
@@ -19,7 +23,7 @@ export const addId = curry((c, aFn, args, o) => {
   if (aFn && aFn.idFrom === 'ARGS') {
     return {
       ...o,
-      __ladda__id: serialize(args)
+      __ladda__id: createIdFromArgs(args)
     };
   }
   const getId_ = getIdGetter(c, aFn);

--- a/src/plugins/cache/id-helper.spec.js
+++ b/src/plugins/cache/id-helper.spec.js
@@ -1,4 +1,4 @@
-import {addId, removeId} from './id-helper';
+import {addId, removeId, EMPTY_ARGS_PLACEHOLDER} from './id-helper';
 
 describe('IdHelper', () => {
   it('removeId is the inverse of addId', () => {
@@ -10,6 +10,13 @@ describe('IdHelper', () => {
     const aFn = {idFrom: 'ARGS'};
     expect(addId({}, aFn, [1, 2, 3], o)).to.deep.equal(
       {...o, __ladda__id: '1-2-3'}
+    );
+  });
+  it('addId handles empty args if idFrom is ARGS', () => {
+    const o = {name: 'kalle'};
+    const aFn = {idFrom: 'ARGS'};
+    expect(addId({}, aFn, [], o)).to.deep.equal(
+      {...o, __ladda__id: EMPTY_ARGS_PLACEHOLDER}
     );
   });
   it('removing id from undefined returns undefined', () => {

--- a/src/plugins/cache/query-cache.js
+++ b/src/plugins/cache/query-cache.js
@@ -68,7 +68,7 @@ const getFromCache = (qc, e, k) => {
 
 // QueryCache -> Entity -> ApiFunction -> [a] -> [b] -> [b]
 export const put = curry((qc, e, aFn, args, xs) => {
-  const k = createKey(e, [aFn.fnName, ...filter(identity, args)]);
+  const k = createKey(e, [aFn.fnName, ...args]);
   if (Array.isArray(xs)) {
     qc.cache[k] = toCacheValue(map(prop('__ladda__id'), xs));
   } else {
@@ -85,7 +85,7 @@ export const getValue = (v) => {
 
 // QueryCache -> Entity -> ApiFunction -> [a] -> Bool
 export const contains = (qc, e, aFn, args) => {
-  const k = createKey(e, [aFn.fnName, ...filter(identity, args)]);
+  const k = createKey(e, [aFn.fnName, ...args]);
   return inCache(qc, k);
 };
 
@@ -97,7 +97,7 @@ export const hasExpired = (qc, e, cv) => (Date.now() - cv.timestamp) > getTtl(e)
 
 // QueryCache -> Config -> Entity -> ApiFunction -> [a] -> Bool
 export const get = (qc, c, e, aFn, args) => {
-  const k = createKey(e, [aFn.fnName, ...filter(identity, args)]);
+  const k = createKey(e, [aFn.fnName, ...args]);
   if (!inCache(qc, k)) {
     throw new Error(
       `Tried to access ${e.name} with key ${k} which doesn't exist.

--- a/src/plugins/cache/serializer.js
+++ b/src/plugins/cache/serializer.js
@@ -1,8 +1,14 @@
+const EMPTY_STRING = '__EMPTY_STRING__';
+
 const serializeObject = (o) => {
   return Object.keys(o).map(x => {
     if (o[x] && typeof o[x] === 'object') {
       return serializeObject(o[x]);
     }
+    if (o[x] === '') {
+      return EMPTY_STRING;
+    }
+
     return o[x];
   }).join('-');
 };


### PR DESCRIPTION
The test should sufficiently document what we're doing here.
We let the serializer contain a special placeholder when there are no args whatsoever, and empty strings are serialized with a special placeholder value, so that they are not ignored during string concatenation.

Closes #7 
Closes #9 
Closes #35 