### PR TITLE
Properly serialize recursive objects

### DIFF
--- a/src/plugins/cache/serializer.js
+++ b/src/plugins/cache/serializer.js
@@ -1,24 +1,16 @@
 const EMPTY_STRING = '__EMPTY_STRING__';
 
-const serializeObject = (o) => {
-  return Object.keys(o).map(x => {
-    if (o[x] && typeof o[x] === 'object') {
-      return serializeObject(o[x]);
-    }
-    if (o[x] === '') {
-      return EMPTY_STRING;
-    }
-
-    return o[x];
-  }).join('-');
-};
-
 export const serialize = (x) => {
   if (x instanceof Date) {
     return x.toISOString();
   }
+  if (x === '') {
+    return EMPTY_STRING;
+  }
   if (x instanceof Object) {
-    return serializeObject(x);
+    return Object.keys(x).map(k =>
+        serialize(x[k])
+    ).join('-');
   }
   return x;
 };

--- a/src/plugins/cache/serializer.spec.js
+++ b/src/plugins/cache/serializer.spec.js
@@ -18,6 +18,13 @@ describe('Serializer', () => {
     const res = serialize({a: 'hello', b: {c: 'world', d: '!'}});
     expect(res).to.equal('hello-world-!');
   });
+  it('serializes nested objects and arrays properly', () => {
+    const a = [[[[1]]]];
+    const d = new Date();
+    const o = {a: {b: d}};
+    expect(serialize(a)).to.equal('1');
+    expect(serialize(o)).to.equal(d.toISOString());
+  });
   it('int serialize to int', () => {
     const res = serialize(1);
     expect(res).to.equal(1);


### PR DESCRIPTION
Treat objects as special case instead of the other way around.

Before, once you started serializing an object, there was no way out again. This problem only surfaces with the introduction of the date serialization.