### PR TITLE
Let Ladda return the same object references - immutable cache

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -121,6 +121,7 @@ const getGlobalConfig = (config) => ({
   idField: 'id',
   enableDeduplication: true,
   useProductionBuild: process.NODE_ENV === 'production',
+  strictMode: true,
   ...(config.__config || {})
 });
 

--- a/src/builder.spec.js
+++ b/src/builder.spec.js
@@ -19,6 +19,9 @@ deleteUser.operation = 'DELETE';
 const noopUser = () => Promise.resolve(['a', 'b']);
 noopUser.operation = 'NO_OPERATION';
 
+const updateUser = (user) => Promise.resolve(user);
+updateUser.operation = 'UPDATE';
+
 const config = () => ({
   user: {
     ttl: 300,
@@ -26,7 +29,8 @@ const config = () => ({
       getUser,
       getUsers,
       deleteUser,
-      noopUser
+      noopUser,
+      updateUser
     },
     invalidates: ['alles']
   },
@@ -564,6 +568,32 @@ describe('builder', () => {
         expect(x.x).to.equal('x');
         return api.x.getX('', '').then((secondX) => {
           expect(secondX.x).to.equal('xxx');
+        });
+      });
+    });
+  });
+
+  describe('immutability', () => {
+    it('does return the same object twice when cache is hit', () => {
+      const myConfig = config();
+      const api = build(myConfig);
+
+      return api.user.getUser('1').then(firstUser => {
+        return api.user.getUser('1').then(secondUser => {
+          expect(firstUser).to.equal(secondUser);
+        });
+      });
+    });
+
+    it('does not return the same object after a cache update', () => {
+      const myConfig = config();
+      const api = build(myConfig);
+
+      return api.user.getUser('1').then(firstUser => {
+        return api.user.updateUser({ id: '1' }).then(() => {
+          return api.user.getUser('1').then(secondUser => {
+            expect(firstUser).not.to.equal(secondUser);
+          });
         });
       });
     });

--- a/src/plugins/cache/cache.js
+++ b/src/plugins/cache/cache.js
@@ -2,8 +2,8 @@ import {curry} from 'ladda-fp';
 import * as QueryCache from './query-cache';
 import * as EntityStore from './entity-store';
 
-export const createCache = (entityConfigs) => {
-  const entityStore = EntityStore.createEntityStore(entityConfigs);
+export const createCache = (entityConfigs, globalConfig = {}) => {
+  const entityStore = EntityStore.createEntityStore(entityConfigs, globalConfig);
   const queryCache = QueryCache.createQueryCache(entityStore);
   return {entityStore, queryCache};
 };

--- a/src/plugins/cache/cache.js
+++ b/src/plugins/cache/cache.js
@@ -2,9 +2,9 @@ import {curry} from 'ladda-fp';
 import * as QueryCache from './query-cache';
 import * as EntityStore from './entity-store';
 
-export const createCache = (entityConfigs, onChange) => {
-  const entityStore = EntityStore.createEntityStore(entityConfigs, onChange);
-  const queryCache = QueryCache.createQueryCache(entityStore, onChange);
+export const createCache = (entityConfigs) => {
+  const entityStore = EntityStore.createEntityStore(entityConfigs);
+  const queryCache = QueryCache.createQueryCache(entityStore);
   return {entityStore, queryCache};
 };
 

--- a/src/plugins/cache/entity-store.spec.js
+++ b/src/plugins/cache/entity-store.spec.js
@@ -64,15 +64,6 @@ describe('EntityStore', () => {
       const r = get(s, e, v.id);
       expect(r.value).to.deep.equal(withId('hello', v));
     });
-    it('altering an added value does not alter the stored value when doing a get later', () => {
-      const s = createEntityStore(config);
-      const v = {id: 'hello', name: 'kalle'};
-      const e = { name: 'user'};
-      put(s, e, addId({}, undefined, undefined, v));
-      v.name = 'ingvar';
-      const r = get(s, e, v.id);
-      expect(r.value.item.name).to.equal('kalle');
-    });
     it('an added value to a view is later returned when calling get for view', () => {
       const s = createEntityStore(config);
       const v = {id: 'hello'};

--- a/src/plugins/cache/entity-store.spec.js
+++ b/src/plugins/cache/entity-store.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 
 import {createEntityStore, put, mPut, get, contains, remove} from './entity-store';
-import {addId} from './id-helper';
+import {addId, withId} from './id-helper';
 
 const config = [
   {
@@ -62,7 +62,7 @@ describe('EntityStore', () => {
       const e = { name: 'user'};
       put(s, e, addId({}, undefined, undefined, v));
       const r = get(s, e, v.id);
-      expect(r.value).to.deep.equal({...v, __ladda__id: 'hello'});
+      expect(r.value).to.deep.equal(withId('hello', v));
     });
     it('altering an added value does not alter the stored value when doing a get later', () => {
       const s = createEntityStore(config);
@@ -71,7 +71,7 @@ describe('EntityStore', () => {
       put(s, e, addId({}, undefined, undefined, v));
       v.name = 'ingvar';
       const r = get(s, e, v.id);
-      expect(r.value.name).to.equal('kalle');
+      expect(r.value.item.name).to.equal('kalle');
     });
     it('an added value to a view is later returned when calling get for view', () => {
       const s = createEntityStore(config);
@@ -79,7 +79,7 @@ describe('EntityStore', () => {
       const e = { name: 'user'};
       put(s, e, addId({}, undefined, undefined, v));
       const r = get(s, e, v.id);
-      expect(r.value).to.deep.equal({...v, __ladda__id: 'hello'});
+      expect(r.value).to.deep.equal(withId('hello', v));
     });
     it('merges view into entity value', () => {
       const s = createEntityStore(config);
@@ -89,7 +89,7 @@ describe('EntityStore', () => {
       put(s, e, addId({}, undefined, undefined, {...v, name: 'kalle'}));
       put(s, eView, addId({}, undefined, undefined, {...v, name: 'ingvar'}));
       const r = get(s, eView, v.id);
-      expect(r.value).to.be.deep.equal({__ladda__id: 'hello', id: 'hello', name: 'ingvar'});
+      expect(r.value).to.be.deep.equal(withId('hello', { id: 'hello', name: 'ingvar' }));
     });
     it('writing view value without id throws error', () => {
       const s = createEntityStore(config);
@@ -118,8 +118,8 @@ describe('EntityStore', () => {
       mPut(s, e, [v1WithId, v2WithId]);
       const r1 = get(s, e, v1.id);
       const r2 = get(s, e, v2.id);
-      expect(r1.value).to.deep.equal({...v1, __ladda__id: 'hello'});
-      expect(r2.value).to.deep.equal({...v2, __ladda__id: 'there'});
+      expect(r1.value).to.deep.equal(withId('hello', v1));
+      expect(r2.value).to.deep.equal(withId('there', v2));
     });
   });
   describe('get', () => {
@@ -131,7 +131,7 @@ describe('EntityStore', () => {
       const r = get(s, e, v.id);
       expect(r.timestamp).to.not.be.undefined;
     });
-    it('altering retrieved value does not alter the stored value', () => {
+    xit('altering retrieved value does not alter the stored value', () => {
       const s = createEntityStore(config);
       const v = {id: 'hello', name: 'kalle'};
       const e = { name: 'user'};
@@ -139,7 +139,7 @@ describe('EntityStore', () => {
       const r = get(s, e, v.id);
       r.value.name = 'ingvar';
       const r2 = get(s, e, v.id);
-      expect(r2.value.name).to.equal(v.name);
+      expect(r2.value.item.name).to.equal(v.name);
     });
     it('gets undefined if value does not exist', () => {
       const s = createEntityStore(config);
@@ -162,7 +162,7 @@ describe('EntityStore', () => {
       put(s, e, addId({}, undefined, undefined, v));
       const eView = {name: 'userPreview', viewOf: 'user'};
       const r = get(s, eView, v.id);
-      expect(r.value).to.be.deep.equal({...v, __ladda__id: 'hello'});
+      expect(r.value).to.be.deep.equal(withId('hello', v));
     });
     it('gets view if only it exist', () => {
       const s = createEntityStore(config);
@@ -170,7 +170,7 @@ describe('EntityStore', () => {
       const eView = {name: 'userPreview', viewOf: 'user'};
       put(s, eView, addId({}, undefined, undefined, v));
       const r = get(s, eView, v.id);
-      expect(r.value).to.be.deep.equal({...v, __ladda__id: 'hello'});
+      expect(r.value).to.be.deep.equal(withId('hello', v));
     });
     it('gets entity value if same timestamp as view value', () => {
       const s = createEntityStore(config);
@@ -180,7 +180,7 @@ describe('EntityStore', () => {
       put(s, eView, addId({}, undefined, undefined, v));
       put(s, e, addId({}, undefined, undefined, {...v, name: 'kalle'}));
       const r = get(s, eView, v.id);
-      expect(r.value).to.be.deep.equal({...v, name: 'kalle', __ladda__id: 'hello'});
+      expect(r.value).to.be.deep.equal(withId('hello', {...v, name: 'kalle' }));
     });
     it('gets entity value if newer than view value', (done) => {
       const s = createEntityStore(config);
@@ -191,7 +191,7 @@ describe('EntityStore', () => {
       setTimeout(() => {
         put(s, e, addId({}, undefined, undefined, {...v, name: 'kalle'}));
         const r = get(s, eView, v.id);
-        expect(r.value).to.be.deep.equal({...v, name: 'kalle', __ladda__id: 'hello'});
+        expect(r.value).to.be.deep.equal(withId('hello', {...v, name: 'kalle' }));
         done();
       }, 1);
     });

--- a/src/plugins/cache/id-helper.js
+++ b/src/plugins/cache/id-helper.js
@@ -19,24 +19,18 @@ export const getId = curry((c, aFn, args, o) => {
   return getIdGetter(c, aFn)(o);
 });
 
+export const withId = (id, item) => ({ __ladda__id: id, item });
+export const withoutId = (itemWithId) => itemWithId.item;
+
 export const addId = curry((c, aFn, args, o) => {
   if (aFn && aFn.idFrom === 'ARGS') {
-    return {
-      ...o,
-      __ladda__id: createIdFromArgs(args)
-    };
+    return withId(createIdFromArgs(args), o);
   }
   const getId_ = getIdGetter(c, aFn);
   if (Array.isArray(o)) {
-    return map(x => ({
-      ...x,
-      __ladda__id: getId_(x)
-    }), o);
+    return map(x => withId(getId_(x), x), o);
   }
-  return {
-    ...o,
-    __ladda__id: getId_(o)
-  };
+  return withId(getId_(o), o);
 });
 
 export const removeId = (o) => {
@@ -45,11 +39,7 @@ export const removeId = (o) => {
   }
 
   if (Array.isArray(o)) {
-    return map(x => {
-      delete x.__ladda__id;
-      return x;
-    }, o);
+    return map(withoutId, o);
   }
-  delete o.__ladda__id;
-  return o;
+  return withoutId(o);
 };

--- a/src/plugins/cache/id-helper.spec.js
+++ b/src/plugins/cache/id-helper.spec.js
@@ -1,4 +1,4 @@
-import {addId, removeId, EMPTY_ARGS_PLACEHOLDER} from './id-helper';
+import {addId, removeId, withId, EMPTY_ARGS_PLACEHOLDER} from './id-helper';
 
 describe('IdHelper', () => {
   it('removeId is the inverse of addId', () => {
@@ -8,29 +8,29 @@ describe('IdHelper', () => {
   it('addId creates id from args if idFrom is ARGS', () => {
     const o = {name: 'kalle'};
     const aFn = {idFrom: 'ARGS'};
-    expect(addId({}, aFn, [1, 2, 3], o)).to.deep.equal(
-      {...o, __ladda__id: '1-2-3'}
-    );
+    expect(addId({}, aFn, [1, 2, 3], o)).to.deep.equal(withId('1-2-3', o));
   });
   it('addId handles empty args if idFrom is ARGS', () => {
     const o = {name: 'kalle'};
     const aFn = {idFrom: 'ARGS'};
-    expect(addId({}, aFn, [], o)).to.deep.equal(
-      {...o, __ladda__id: EMPTY_ARGS_PLACEHOLDER}
-    );
+    expect(addId({}, aFn, [], o)).to.deep.equal(withId(EMPTY_ARGS_PLACEHOLDER, o));
   });
   it('removing id from undefined returns undefined', () => {
     const o = undefined;
     expect(removeId(o)).to.equal(o);
   });
   it('removing id from array remove it from individual elements', () => {
-    const o = [{__ladda__id: 1, id: 1}, {__ladda__id: 2, id: 2}, {__ladda__id: 3, id: 3}];
+    const o = [
+      {__ladda__id: 1, item: { id: 1 } },
+      {__ladda__id: 2, item: { id: 2 } },
+      {__ladda__id: 3, item: { id: 3 } }
+    ];
     expect(removeId(o)).to.deep.equal([{id: 1}, {id: 2}, {id: 3}]);
   });
   it('addId can use a custom function', () => {
     const o = {myId: 15};
     const aFn = {idFrom: x => x.myId};
     const res = addId({}, aFn, [1, 2, 3], o);
-    expect(res).to.deep.equal({...o, __ladda__id: 15});
+    expect(res).to.deep.equal(withId(15, o));
   });
 });

--- a/src/plugins/cache/index.js
+++ b/src/plugins/cache/index.js
@@ -34,7 +34,7 @@ const notify = curry((onChange, entity, fn, args, payload) => {
 });
 
 export const cachePlugin = (onChange) => ({ config, entityConfigs }) => {
-  const cache = createCache(values(entityConfigs));
+  const cache = createCache(values(entityConfigs), config);
   return ({ entity, fn }) => {
     const handler = HANDLERS[fn.operation];
     const notify_ = notify(onChange, entity, fn);

--- a/src/plugins/cache/operations/command.js
+++ b/src/plugins/cache/operations/command.js
@@ -6,7 +6,7 @@ export function decorateCommand(c, cache, notify, e, aFn) {
   return (...args) => {
     return aFn(...args)
       .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)))
-      .then(passThrough((o) => Cache.storeEntity(cache, e, addId(c, undefined, undefined, o))))
+      .then((o) => Cache.storeEntity(cache, e, addId(c, undefined, undefined, o)))
       .then(passThrough((o) => notify([...args], o)));
   };
 }

--- a/src/plugins/cache/operations/command.spec.js
+++ b/src/plugins/cache/operations/command.spec.js
@@ -5,6 +5,7 @@ import {curry} from 'ladda-fp';
 import {decorateCommand} from './command';
 import * as Cache from '../cache';
 import {createApiFunction} from '../test-helper';
+import {withId} from '../id-helper';
 
 const curryNoop = () => () => {};
 
@@ -32,7 +33,7 @@ describe('Command', () => {
 
       const res = decorateCommand({}, cache, curryNoop, e, aFn);
       return res('an arg', 'other args').then((nextXOrg) => {
-        expect(Cache.getEntity(cache, e, 1).value).to.deep.equal({...nextXOrg, __ladda__id: 1});
+        expect(Cache.getEntity(cache, e, 1).value).to.deep.equal(withId(1, nextXOrg));
       });
     });
 

--- a/src/plugins/cache/operations/create.js
+++ b/src/plugins/cache/operations/create.js
@@ -6,7 +6,7 @@ export function decorateCreate(c, cache, notify, e, aFn) {
   return (...args) => {
     return aFn(...args)
       .then(passThrough(() => invalidateQuery(cache, e, aFn)))
-      .then(passThrough(compose(storeEntity(cache, e), addId(c, aFn, args))))
+      .then(compose(storeEntity(cache, e), addId(c, aFn, args)))
       .then(passThrough(compose(storeCreateEvent(cache, e), getId(c, aFn, args))))
       .then(passThrough(notify(args)));
   };

--- a/src/plugins/cache/operations/create.spec.js
+++ b/src/plugins/cache/operations/create.spec.js
@@ -5,6 +5,7 @@ import {curry} from 'ladda-fp';
 import {decorateCreate} from './create';
 import {createCache, getEntity} from '../cache';
 import {createApiFunction} from '../test-helper';
+import {withId} from '../id-helper';
 
 const curryNoop = () => () => {};
 
@@ -54,7 +55,7 @@ describe('Create', () => {
       const res = decorateCreate({}, cache, curryNoop, e, aFn);
       return res(xOrg).then((newX) => {
         expect(newX).to.equal(response);
-        expect(getEntity(cache, e, 1).value).to.deep.equal({...response, __ladda__id: 1});
+        expect(getEntity(cache, e, 1).value).to.deep.equal(withId(1, response));
       });
     });
 

--- a/src/plugins/cache/operations/read.js
+++ b/src/plugins/cache/operations/read.js
@@ -20,7 +20,7 @@ const decorateReadSingle = (c, cache, notify, e, aFn) => {
     }
 
     return aFn(id)
-      .then(passThrough(compose(Cache.storeEntity(cache, e), addId(c, aFn, id))))
+      .then(compose(Cache.storeEntity(cache, e), addId(c, aFn, id)))
       .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)))
       .then(passThrough(notify([id])));
   };
@@ -46,7 +46,7 @@ const decorateReadSome = (c, cache, notify, e, aFn) => {
     const addIds = map(([id, item]) => addId(c, aFn, id, item));
 
     return aFn(remaining)
-      .then(passThrough(compose(Cache.storeEntities(cache, e), addIds, zip(remaining))))
+      .then(compose(Cache.storeEntities(cache, e), addIds, zip(remaining)))
       .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)))
       .then((other) => {
         const asMap = compose(toIdMap, concat)(cached, other);
@@ -66,9 +66,7 @@ const decorateReadQuery = (c, cache, notify, e, aFn) => {
     }
 
     return aFn(...args)
-      .then(passThrough(
-            compose(Cache.storeQueryResponse(cache, e, aFn, args),
-                    addId(c, aFn, args))))
+      .then(compose(Cache.storeQueryResponse(cache, e, aFn, args), addId(c, aFn, args)))
       .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)))
       .then(passThrough(notify(args)));
   };

--- a/src/plugins/cache/operations/read.spec.js
+++ b/src/plugins/cache/operations/read.spec.js
@@ -273,7 +273,7 @@ describe('Read', () => {
       const aFn = sinon.spy(aFnWithoutSpy);
       const res = decorateRead({}, cache, curryNoop, e, aFn);
       return res(1).then((x) => {
-        expect(x).to.equal(xOrg);
+        expect(x).to.deep.equal(xOrg);
       });
     });
 

--- a/src/plugins/cache/operations/update.js
+++ b/src/plugins/cache/operations/update.js
@@ -6,7 +6,7 @@ export function decorateUpdate(c, cache, notify, e, aFn) {
   return (eValue, ...args) => {
     return aFn(eValue, ...args)
       .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)))
-      .then(passThrough(() => Cache.storeEntity(cache, e, addId(c, undefined, undefined, eValue))))
+      .then(() => Cache.storeEntity(cache, e, addId(c, undefined, undefined, eValue)))
       .then(passThrough(() => notify([eValue, ...args], eValue)));
   };
 }

--- a/src/plugins/cache/operations/update.spec.js
+++ b/src/plugins/cache/operations/update.spec.js
@@ -5,6 +5,7 @@ import {curry} from 'ladda-fp';
 import {decorateUpdate} from './update';
 import * as Cache from '../cache';
 import {createApiFunction} from '../test-helper';
+import {withId} from '../id-helper';
 
 const curryNoop = () => () => {};
 
@@ -53,7 +54,7 @@ describe('Update', () => {
 
       const res = decorateUpdate({}, cache, curryNoop, e, aFn);
       return res(xOrg, 'other args').then(() => {
-        expect(Cache.getEntity(cache, e, 1).value).to.deep.equal({...xOrg, __ladda__id: 1});
+        expect(Cache.getEntity(cache, e, 1).value).to.deep.equal(withId(1, xOrg));
       });
     });
 

--- a/src/plugins/cache/query-cache.js
+++ b/src/plugins/cache/query-cache.js
@@ -5,7 +5,7 @@
 
 import {on2, prop, join, reduce, identity, toPairs, flatten,
         curry, map, map_, startsWith, compose, filter} from 'ladda-fp';
-import {mPut as mPutInEs, get as getFromEs} from './entity-store';
+import {mPut as mPutInEs, put as putInEs, get as getFromEs} from './entity-store';
 import {serialize} from './serializer';
 import {removeId, addId} from './id-helper';
 
@@ -76,7 +76,7 @@ export const put = curry((qc, e, aFn, args, xs) => {
   }
   return Array.isArray(xs) ?
     mPutInEs(qc.entityStore, e, xs) :
-    mPutInEs(qc.entityStore, e, [xs])[0];
+    putInEs(qc.entityStore, e, xs);
 });
 
 // (CacheValue | [CacheValue]) -> Promise

--- a/src/plugins/cache/query-cache.js
+++ b/src/plugins/cache/query-cache.js
@@ -74,8 +74,9 @@ export const put = curry((qc, e, aFn, args, xs) => {
   } else {
     qc.cache[k] = toCacheValue(prop('__ladda__id', xs));
   }
-  mPutInEs(qc.entityStore, e, Array.isArray(xs) ? xs : [xs]);
-  return xs;
+  return Array.isArray(xs) ?
+    mPutInEs(qc.entityStore, e, xs) :
+    mPutInEs(qc.entityStore, e, [xs])[0];
 });
 
 // (CacheValue | [CacheValue]) -> Promise

--- a/src/plugins/cache/query-cache.spec.js
+++ b/src/plugins/cache/query-cache.spec.js
@@ -75,7 +75,11 @@ describe('QueryCache', () => {
       const aFn = (x) => x;
       const args = [1, 2, 3];
       const xs = [{id: 1}, {id: 2}, {id: 3}];
-      const xsRet = [{id: 1, __ladda__id: 1}, {id: 2, __ladda__id: 2}, {id: 3, __ladda__id: 3}];
+      const xsRet = [
+        { item: { id: 1 }, __ladda__id: 1 },
+        { item: { id: 2 }, __ladda__id: 2 },
+        { item: { id: 3 }, __ladda__id: 3 }
+      ];
       put(qc, e, aFn, args, addId({}, undefined, undefined, xs));
       expect(getValue(get(qc, undefined, e, aFn, args).value)).to.deep.equal(xsRet);
     });


### PR DESCRIPTION
A current pain point with Ladda IMO is that every cache hit gives you a new reference to a cached object. While this is super-safe and makes it impossible to destroy the cache through mutation, it's also a strange contract - especially given current practices around dealing with immutable objects in e.g. React.

The issue is resolved here.
For backwards compatibility there's a global flag called `strict` which defaults to `true`. It performs an Object.freeze on cache objects, so that we can still guarantee that our cache is not unlawfully manipulated.
However, some past users might have violated this rule in the past - `strict: false` would keep their code alive at least.
In addition the flag can be set to false when you just don't want these safeties - we deep freeze everything. Not sure how freeze performs - probably quite quick - still, adds some overhead.

This was done a while ago already - I think it's time to merge it.

On the branch `fix/id-from-args-with-lists` I just pushed a seemingly unrelated broken test I discovered earlier. This test would also be fixed by the changes made in this PR.


cc @mlent