### PR TITLE
fix(update) Pass api function to Cache.storeEntity

### DIFF
--- a/src/plugins/cache/operations/update.js
+++ b/src/plugins/cache/operations/update.js
@@ -6,7 +6,7 @@ export function decorateUpdate(c, cache, notify, e, aFn) {
   return (eValue, ...args) => {
     return aFn(eValue, ...args)
       .then(passThrough(() => Cache.invalidateQuery(cache, e, aFn)))
-      .then(passThrough(() => Cache.storeEntity(cache, e, addId(c, undefined, undefined, eValue))))
+      .then(passThrough(() => Cache.storeEntity(cache, e, addId(c, aFn, undefined, eValue))))
       .then(passThrough(() => notify([eValue, ...args], eValue)));
   };
 }

--- a/src/plugins/cache/operations/update.spec.js
+++ b/src/plugins/cache/operations/update.spec.js
@@ -1,10 +1,10 @@
 /* eslint-disable no-unused-expressions */
 
 import sinon from 'sinon';
-import {curry} from 'ladda-fp';
-import {decorateUpdate} from './update';
+import { curry } from 'ladda-fp';
+import { decorateUpdate } from './update';
 import * as Cache from '../cache';
-import {createApiFunction} from '../test-helper';
+import { createApiFunction } from '../test-helper';
 
 const curryNoop = () => () => {};
 
@@ -13,9 +13,9 @@ const config = [
     name: 'user',
     ttl: 300,
     api: {
-      getUsers: (x) => x,
-      getUsers2: (x) => x,
-      deleteUser: (x) => x
+      getUsers: x => x,
+      getUsers2: x => x,
+      deleteUser: x => x
     },
     invalidates: ['user'],
     invalidatesOn: ['GET']
@@ -24,8 +24,8 @@ const config = [
     name: 'userPreview',
     ttl: 200,
     api: {
-      getPreviews: (x) => x,
-      updatePreview: (x) => x
+      getPreviews: x => x,
+      updatePreview: x => x
     },
     invalidates: ['fda'],
     viewOf: 'user'
@@ -34,8 +34,8 @@ const config = [
     name: 'listUser',
     ttl: 200,
     api: {
-      getPreviews: (x) => x,
-      updatePreview: (x) => x
+      getPreviews: x => x,
+      updatePreview: x => x
     },
     invalidates: ['fda'],
     viewOf: 'user'
@@ -47,13 +47,13 @@ describe('Update', () => {
     it('Updates cache based on argument', () => {
       const cache = Cache.createCache(config);
       const e = config[0];
-      const xOrg = {id: 1, name: 'Kalle'};
+      const xOrg = { id: 1, name: 'Kalle' };
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg));
       const aFn = sinon.spy(aFnWithoutSpy);
 
       const res = decorateUpdate({}, cache, curryNoop, e, aFn);
       return res(xOrg, 'other args').then(() => {
-        expect(Cache.getEntity(cache, e, 1).value).to.deep.equal({...xOrg, __ladda__id: 1});
+        expect(Cache.getEntity(cache, e, 1).value).to.deep.equal({ ...xOrg, __ladda__id: 1 });
       });
     });
 
@@ -63,7 +63,7 @@ describe('Update', () => {
 
       const cache = Cache.createCache(config);
       const e = config[0];
-      const xOrg = {id: 1, name: 'Kalle'};
+      const xOrg = { id: 1, name: 'Kalle' };
       const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg));
       const aFn = sinon.spy(aFnWithoutSpy);
 
@@ -71,6 +71,21 @@ describe('Update', () => {
       return res(xOrg, 'other args').then(() => {
         expect(spy).to.have.been.calledOnce;
         expect(spy).to.have.been.calledWith([xOrg, 'other args'], xOrg);
+      });
+    });
+  });
+  describe('with idFrom set', () => {
+    it('Updates the cache based on idFrom', () => {
+      const cache = Cache.createCache(config);
+      const e = config[0];
+      const xOrg = { objectId: 1, name: 'Kalle' };
+      const aFnWithoutSpy = createApiFunction(() => Promise.resolve(xOrg),
+      { idFrom: o => o.objectId });
+      const aFn = sinon.spy(aFnWithoutSpy);
+
+      const res = decorateUpdate({}, cache, curryNoop, e, aFn);
+      return res(xOrg, 'other args').then(() => {
+        expect(Cache.getEntity(cache, e, 1).value).to.deep.equal({ ...xOrg, __ladda__id: 1 });
       });
     });
   });


### PR DESCRIPTION
Passing aFn through allows the id to be identified when the client uses idFrom