### PR TITLE
[Query-Cache] Fix invalidation matching

### DIFF
--- a/src/plugins/cache/query-cache.js
+++ b/src/plugins/cache/query-cache.js
@@ -137,7 +137,7 @@ const shouldInvalidateEntity = (e, op) => {
 const invalidateEntity = curry((qc, entityName) => {
   const keys = Object.keys(qc.cache);
   const removeIfEntity = k => {
-    if (startsWith(entityName, k)) {
+    if (startsWith(`${entityName}-`, k)) {
       delete qc.cache[k];
     }
   };

--- a/src/plugins/cache/query-cache.spec.js
+++ b/src/plugins/cache/query-cache.spec.js
@@ -112,5 +112,18 @@ describe('QueryCache', () => {
       const fn = () => invalidate(qc, eBikes, aFn);
       expect(fn).to.not.throw();
     });
+    it('does not invalidate other cache that starts with the same string', () => {
+      const es = createEntityStore(config);
+      const qc = createQueryCache(es);
+      const eCars = config[2];
+      const eUserSettings = config[4];
+      const aFn = createApiFunction(x => x, {operation: 'CREATE'});
+      const args = [1, 2, 3];
+      const xs = [{id: 1}, {id: 2}, {id: 3}];
+      put(qc, eUserSettings, aFn, args, addId({}, undefined, undefined, xs));
+      invalidate(qc, eCars, aFn);
+      const hasUserSettings = contains(qc, eUserSettings, aFn, args);
+      expect(hasUserSettings).to.be.true;
+    });
   });
 });

--- a/src/plugins/cache/test-helper.js
+++ b/src/plugins/cache/test-helper.js
@@ -56,6 +56,13 @@ export const createSampleConfig = () => {
         getCars: createApiFunction(identity, {operation: 'READ'}),
         updateCar: createApiFunction(identity, {operation: 'UPDATE'})
       }
+    }),
+    createEntityConfig({
+      name: 'userSettings',
+      api: {
+        getSettings: createApiFunction(identity, {operation: 'READ'}),
+        updateSettings: createApiFunction(identity, {operation: 'UPDATE'})
+      }
     })
   ];
 };


### PR DESCRIPTION
Query caches were invalidated by a simple `startsWith` check, so it would also match unrelated caches if they started with the same name. E.g. when invalidating `user` it would also invalidate `userSettings`.